### PR TITLE
Run `grblas.init` when testing installed version of grblas.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,17 +24,3 @@ def pytest_addoption(parser):
         action="store_false",
         help="run in non-blocking mode",
     )
-
-
-def pytest_configure(config):
-    backend = config.getoption("--backend")
-    blocking = config.getoption("--blocking")
-    import grblas
-
-    grblas.init(backend, blocking=blocking)
-    print(f'Running tests with "{backend}" backend, blocking={blocking}')
-
-
-def pytest_runtest_setup(item):
-    if "slow" in item.keywords and not item.config.getoption("--runslow"):
-        pytest.skip("need --runslow option to run")

--- a/grblas/tests/conftest.py
+++ b/grblas/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+def pytest_configure(config):
+    backend = config.getoption("--backend", "suitesparse")
+    blocking = config.getoption("--blocking", True)
+    import grblas
+
+    grblas.init(backend, blocking=blocking)
+    print(f'Running tests with "{backend}" backend, blocking={blocking}')
+
+
+def pytest_runtest_setup(item):
+    if "slow" in item.keywords and not item.config.getoption("--runslow", True):
+        pytest.skip("need --runslow option to run")


### PR DESCRIPTION
We need the top-level conftest.py for reasons, but this isn't currently available
when we test `grblas` when it's been installed.  So, let's move a couple pytest
setup functions to grblas/tests/conftest.py.  I don't know if this is considered
best practice, but it seems to check all the boxes for what I want.

When testing locally, we still have our nice options like --runslow and --nonblocking,
but when testing installed, we only test blocking suitesparse, and we don't skip slow.