### PR TITLE
`to_values` returns numpy array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
     # Make sure all top-level imports work
     - ( for attr in Matrix Scalar Vector backends base binary descriptor dtypes exceptions expr ffi formatting init io lib mask matrix monoid ops scalar semiring tests unary vector ; do echo python -c \"from grblas import $attr\" ; if ! python -c "from grblas import $attr" ; then exit 1 ; fi ; done )
     # Make sure notebooks execute
-    - conda install -c conda-forge matplotlib nbconvert jupyter flake8 black
+    - conda install -c conda-forge matplotlib nbconvert jupyter "ipython>=7.0" flake8 black
     - jupyter nbconvert --to notebook --execute notebooks/*ipynb
     # Style checks
     - flake8 grblas *.py

--- a/grblas/dtypes.py
+++ b/grblas/dtypes.py
@@ -52,7 +52,9 @@ UINT64 = DataType("UINT64", lib.GrB_UINT64, "uint64_t", numba.types.uint64, np.u
 FP32 = DataType("FP32", lib.GrB_FP32, "float", numba.types.float32, np.float32)
 FP64 = DataType("FP64", lib.GrB_FP64, "double", numba.types.float64, np.float64)
 FC32 = DataType("FC32", libget("GrB_FC32"), "float _Complex", numba.types.complex64, np.complex64)
-FC64 = DataType("FC64", libget("GrB_FC64"), "double _Complex", numba.types.complex128, np.complex128)
+FC64 = DataType(
+    "FC64", libget("GrB_FC64"), "double _Complex", numba.types.complex128, np.complex128
+)
 
 # Used for testing user-defined functions
 _sample_values = {

--- a/grblas/dtypes.py
+++ b/grblas/dtypes.py
@@ -57,13 +57,21 @@ UINT64 = DataType("UINT64", lib.GrB_UINT64, "GrB_UINT64", "uint64_t", numba.type
 FP32 = DataType("FP32", lib.GrB_FP32, "GrB_FP32", "float", numba.types.float32, np.float32)
 FP64 = DataType("FP64", lib.GrB_FP64, "GrB_FP64", "double", numba.types.float64, np.float64)
 if hasattr(lib, "GxB_FC32"):  # pragma: no cover
-    FC32 = DataType("FC32", lib.GxB_FC32, "GxB_FC32", "float _Complex", numba.types.complex64, np.complex64)
+    FC32 = DataType(
+        "FC32", lib.GxB_FC32, "GxB_FC32", "float _Complex", numba.types.complex64, np.complex64
+    )
 if hasattr(lib, "GrB_FC32"):  # pragma: no cover
-    FC32 = DataType("FC32", lib.GrB_FC32, "GrB_FC32", "float _Complex", numba.types.complex64, np.complex64)
+    FC32 = DataType(
+        "FC32", lib.GrB_FC32, "GrB_FC32", "float _Complex", numba.types.complex64, np.complex64
+    )
 if hasattr(lib, "GxB_FC64"):  # pragma: no cover
-    FC64 = DataType("FC64", lib.GxB_FC64, "GxB_FC64", "double _Complex", numba.types.complex128, np.complex128)
+    FC64 = DataType(
+        "FC64", lib.GxB_FC64, "GxB_FC64", "double _Complex", numba.types.complex128, np.complex128
+    )
 if hasattr(lib, "GrB_FC64"):  # pragma: no cover
-    FC64 = DataType("FC64", lib.GrB_FC64, "GrB_FC64", "double _Complex", numba.types.complex128, np.complex128)
+    FC64 = DataType(
+        "FC64", lib.GrB_FC64, "GrB_FC64", "double _Complex", numba.types.complex128, np.complex128
+    )
 
 # Used for testing user-defined functions
 _sample_values = {

--- a/grblas/dtypes.py
+++ b/grblas/dtypes.py
@@ -18,11 +18,12 @@ def libget(name):
 
 
 class DataType:
-    def __init__(self, name, gb_type, c_type, numba_type):
+    def __init__(self, name, gb_type, c_type, numba_type, np_type):
         self.name = name
         self.gb_type = gb_type
         self.c_type = c_type
         self.numba_type = numba_type
+        self.np_type = np_type
 
     def __repr__(self):
         return self.name
@@ -39,19 +40,19 @@ class DataType:
                 raise TypeError(f"Invalid or unknown datatype: {other}")
 
 
-BOOL = DataType("BOOL", lib.GrB_BOOL, "_Bool", numba.types.bool_)
-INT8 = DataType("INT8", lib.GrB_INT8, "int8_t", numba.types.int8)
-UINT8 = DataType("UINT8", lib.GrB_UINT8, "uint8_t", numba.types.uint8)
-INT16 = DataType("INT16", lib.GrB_INT16, "int16_t", numba.types.int16)
-UINT16 = DataType("UINT16", lib.GrB_UINT16, "uint16_t", numba.types.uint16)
-INT32 = DataType("INT32", lib.GrB_INT32, "int32_t", numba.types.int32)
-UINT32 = DataType("UINT32", lib.GrB_UINT32, "uint32_t", numba.types.uint32)
-INT64 = DataType("INT64", lib.GrB_INT64, "int64_t", numba.types.int64)
-UINT64 = DataType("UINT64", lib.GrB_UINT64, "uint64_t", numba.types.uint64)
-FP32 = DataType("FP32", lib.GrB_FP32, "float", numba.types.float32)
-FP64 = DataType("FP64", lib.GrB_FP64, "double", numba.types.float64)
-FC32 = DataType("FC32", libget("GrB_FC32"), "float _Complex", numba.types.complex64)
-FC64 = DataType("FC64", libget("GrB_FC64"), "double _Complex", numba.types.complex128)
+BOOL = DataType("BOOL", lib.GrB_BOOL, "_Bool", numba.types.bool_, np.bool_)
+INT8 = DataType("INT8", lib.GrB_INT8, "int8_t", numba.types.int8, np.int8)
+UINT8 = DataType("UINT8", lib.GrB_UINT8, "uint8_t", numba.types.uint8, np.uint8)
+INT16 = DataType("INT16", lib.GrB_INT16, "int16_t", numba.types.int16, np.int16)
+UINT16 = DataType("UINT16", lib.GrB_UINT16, "uint16_t", numba.types.uint16, np.uint16)
+INT32 = DataType("INT32", lib.GrB_INT32, "int32_t", numba.types.int32, np.int32)
+UINT32 = DataType("UINT32", lib.GrB_UINT32, "uint32_t", numba.types.uint32, np.uint32)
+INT64 = DataType("INT64", lib.GrB_INT64, "int64_t", numba.types.int64, np.int64)
+UINT64 = DataType("UINT64", lib.GrB_UINT64, "uint64_t", numba.types.uint64, np.uint64)
+FP32 = DataType("FP32", lib.GrB_FP32, "float", numba.types.float32, np.float32)
+FP64 = DataType("FP64", lib.GrB_FP64, "double", numba.types.float64, np.float64)
+FC32 = DataType("FC32", libget("GrB_FC32"), "float _Complex", numba.types.complex64, np.complex64)
+FC64 = DataType("FC64", libget("GrB_FC64"), "double _Complex", numba.types.complex128, np.complex128)
 
 # Used for testing user-defined functions
 _sample_values = {

--- a/grblas/expr.py
+++ b/grblas/expr.py
@@ -1,4 +1,5 @@
 from . import ffi, lib
+import numpy as np
 
 ffi_new = ffi.new
 NULL = ffi.NULL
@@ -47,10 +48,10 @@ class IndexerResolver:
         return out
 
     def parse_index(self, index, typ, size):
-        if typ is int:
+        if np.issubdtype(typ, np.integer):
             if index >= size:
                 raise IndexError(f"index={index}, size={size}")
-            return index, None
+            return int(index), None
         if typ is slice:
             if index == slice(None):
                 # [:] means all indices; use special GrB_ALL indicator

--- a/grblas/expr.py
+++ b/grblas/expr.py
@@ -96,6 +96,12 @@ class IndexerResolver:
                 # [:] means all indices; use special GrB_ALL indicator
                 return _ALL_INDICES, _CScalar(size)
             index = tuple(range(size)[index])
+        elif typ is np.ndarray:
+            if len(index.shape) != 1:
+                raise TypeError(f"Invalid number of dimensions for index: {len(index.shape)}")
+            if not np.issubdtype(index.dtype, np.integer):
+                raise TypeError(f"Invalid dtype for index: {index.dtype}")
+            return _CArray(index, from_buffer=True), _CScalar(len(index))
         elif typ is not list:
             try:
                 index = tuple(index)

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -159,9 +159,11 @@ class Matrix(BaseType):
         n[0] = self.nvals
         func = libget(f"GrB_Matrix_extractTuples_{self.dtype.name}")
         check_status(func(rows, columns, values, n, self.gb_obj[0]))
-        return (np.frombuffer(ffi.buffer(rows), dtype=np.uint64),
-                np.frombuffer(ffi.buffer(columns), dtype=np.uint64),
-                np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type))
+        return (
+            np.frombuffer(ffi.buffer(rows), dtype=np.uint64),
+            np.frombuffer(ffi.buffer(columns), dtype=np.uint64),
+            np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type)
+        )
 
     def build(self, rows, columns, values, *, dup_op=None, clear=False, nrows=None, ncols=None):
         np_rows = isinstance(rows, np.ndarray)
@@ -282,7 +284,7 @@ class Matrix(BaseType):
                 raise ValueError("No values provided. Unable to determine type.")
             dtype = varr.dtype
             if dtype == object:
-                raise ValueError(f"Unable to convert values to a usable dtype")
+                raise ValueError("Unable to convert values to a usable dtype")
         dtype = lookup_dtype(dtype)
         if varr.dtype != dtype.np_type:
             varr = varr.astype(dtype.np_type)
@@ -295,9 +297,9 @@ class Matrix(BaseType):
             if len(carr) <= 0:
                 raise ValueError("No column indices provided. Unable to infer ncols.")
             ncols = int(carr.max() + 1)
-        if len(rarr) > 0 and 'int' not in rarr.dtype.name:
+        if len(rarr) > 0 and "int" not in rarr.dtype.name:
             raise ValueError(f"row indices must be integers, not {rarr.dtype.name}")
-        if len(carr) > 0 and 'int' not in carr.dtype.name:
+        if len(carr) > 0 and "int" not in carr.dtype.name:
             raise ValueError(f"column indices must be integers, not {carr.dtype.name}")
         # Create the new matrix
         C = cls.new(dtype, nrows, ncols, name=name)

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -162,7 +162,7 @@ class Matrix(BaseType):
         return (
             np.frombuffer(ffi.buffer(rows), dtype=np.uint64),
             np.frombuffer(ffi.buffer(columns), dtype=np.uint64),
-            np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type)
+            np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type),
         )
 
     def build(self, rows, columns, values, *, dup_op=None, clear=False, nrows=None, ncols=None):

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1,5 +1,6 @@
 import pytest
 import grblas
+import numpy as np
 from grblas import Matrix, Vector, Scalar
 from grblas import unary, binary, monoid, semiring
 from grblas import dtypes
@@ -149,13 +150,13 @@ def test_build(A):
 
 def test_extract_values(A):
     rows, cols, vals = A.to_values()
-    assert rows == (0, 0, 1, 1, 2, 3, 3, 4, 5, 6, 6, 6)
-    assert cols == (1, 3, 4, 6, 5, 0, 2, 5, 2, 2, 3, 4)
-    assert vals == (2, 3, 8, 4, 1, 3, 3, 7, 1, 5, 7, 3)
+    np.testing.assert_array_equal(rows, (0, 0, 1, 1, 2, 3, 3, 4, 5, 6, 6, 6))
+    np.testing.assert_array_equal(cols, (1, 3, 4, 6, 5, 0, 2, 5, 2, 2, 3, 4))
+    np.testing.assert_array_equal(vals, (2, 3, 8, 4, 1, 3, 3, 7, 1, 5, 7, 3))
     Trows, Tcols, Tvals = A.T.to_values()
-    assert rows == Tcols
-    assert cols == Trows
-    assert vals == Tvals
+    np.testing.assert_array_equal(rows, Tcols)
+    np.testing.assert_array_equal(cols, Trows)
+    np.testing.assert_array_equal(vals, Tvals)
 
 
 def test_extract_element(A):

--- a/grblas/tests/test_numpyops.py
+++ b/grblas/tests/test_numpyops.py
@@ -23,12 +23,12 @@ def test_bool_doesnt_get_too_large():
     b = grblas.Vector.from_values([0, 1, 2, 3], [True, True, False, False])
     z = a.ewise_mult(b, grblas.monoid.numpy.add).new()
     x, y = z.to_values()
-    assert y == (True, True, True, False)
+    np.testing.assert_array_equal(y, (True, True, True, False))
 
     op = grblas.ops.UnaryOp.register_anonymous(lambda x: np.add(x, x))
     z = a.apply(op).new()
     x, y = z.to_values()
-    assert y == (True, False, True, False)
+    np.testing.assert_array_equal(y, (True, False, True, False))
 
 
 @pytest.mark.slow

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -270,6 +270,13 @@ def test_extract(v):
     assert w2.isequal(w)
 
 
+def test_extract_array(v):
+    w = Vector.new(v.dtype, 3)
+    result = Vector.from_values(np.array([0, 1]), np.array([1, 1]), size=3)
+    w << v[np.array([1, 3, 5])]
+    assert w.isequal(result)
+
+
 def test_extract_fancy_scalars(v):
     assert v.dtype == dtypes.INT64
     s = v[1].new()

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -121,8 +121,8 @@ def test_build(v):
 
 def test_extract_values(v):
     idx, vals = v.to_values()
-    assert idx == (1, 3, 4, 6)
-    assert vals == (1, 1, 2, 0)
+    np.testing.assert_array_equal(idx, (1, 3, 4, 6))
+    np.testing.assert_array_equal(vals, (1, 1, 2, 0))
 
 
 def test_extract_element(v):

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -145,7 +145,7 @@ class Vector(BaseType):
         check_status(func(indices, values, n, self.gb_obj[0]))
         return (
             np.frombuffer(ffi.buffer(indices), dtype=np.uint64),
-            np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type)
+            np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type),
         )
 
     def build(self, indices, values, *, dup_op=None, clear=False, size=None):

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -1,4 +1,5 @@
 import itertools
+import numpy as np
 from . import ffi, lib, backend, binary, monoid, semiring
 from .base import BaseExpression, BaseType
 from .dtypes import libget, lookup_dtype, unify
@@ -134,7 +135,7 @@ class Vector(BaseType):
     def to_values(self):
         """
         GrB_Vector_extractTuples
-        Extract the indices and values as 2 generators
+        Extract the indices and values as a 2-tuple of numpy arrays
         """
         indices = ffi_new("GrB_Index[]", self.nvals)
         values = ffi_new(f"{self.dtype.c_type}[]", self.nvals)
@@ -142,21 +143,25 @@ class Vector(BaseType):
         n[0] = self.nvals
         func = libget(f"GrB_Vector_extractTuples_{self.dtype.name}")
         check_status(func(indices, values, n, self.gb_obj[0]))
-        return tuple(indices), tuple(values)
+        return (np.frombuffer(ffi.buffer(indices), dtype=np.uint64),
+                np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type))
 
-    def build(self, indices, values, *, dup_op=None, clear=False):
-        # TODO: add `size` option once .resize is available
-        if not isinstance(indices, (tuple, list)):
+    def build(self, indices, values, *, dup_op=None, clear=False, size=None):
+        np_index = isinstance(indices, np.ndarray)
+        if not np_index and not isinstance(indices, (tuple, list)):
             indices = tuple(indices)
-        if not isinstance(values, (tuple, list)):
+        np_value = isinstance(values, np.ndarray)
+        if not np_value and not isinstance(values, (tuple, list)):
             values = tuple(values)
-        if len(indices) != len(values):
+        n = len(values)
+        if len(indices) != n:
             raise ValueError(
-                f"`indices` and `values` have different lengths " f"{len(indices)} != {len(values)}"
+                f"`indices` and `values` lengths must match: {len(indices)} != {len(values)}"
             )
         if clear:
             self.clear()
-        n = len(indices)
+        if size is not None:
+            self.resize(size)
         if n <= 0:
             return
 
@@ -166,13 +171,21 @@ class Vector(BaseType):
         dup_op = get_typed_op(dup_op, self.dtype)
         self._expect_op(dup_op, "BinaryOp", within="build", argname="dup_op")
 
-        indices = ffi_new("GrB_Index[]", indices)
-        values = ffi_new(f"{self.dtype.c_type}[]", values)
+        if np_index:
+            uindices = indices.astype(np.uint64, copy=False)
+            indices = ffi.cast("GrB_Index*", ffi.from_buffer(uindices))
+        else:
+            indices = ffi_new("GrB_Index[]", indices)
+        if np_value:
+            verified_values = values.astype(self.dtype.np_type, copy=False)
+            values = ffi.cast(f"{self.dtype.c_type}*", ffi.from_buffer(verified_values))
+        else:
+            values = ffi_new(f"{self.dtype.c_type}[]", values)
         # Push values into w
         func = libget(f"GrB_Vector_build_{self.dtype.name}")
         check_status(func(self.gb_obj[0], indices, values, n, dup_op.gb_obj))
         # Check for duplicates when dup_op was not provided
-        if not dup_op_given and self.nvals < len(values):
+        if not dup_op_given and self.nvals < n:
             raise ValueError("Duplicate indices found, must provide `dup_op` BinaryOp")
 
     def dup(self, *, dtype=None, mask=None, name=None):
@@ -206,24 +219,35 @@ class Vector(BaseType):
         """Create a new Vector from the given lists of indices and values.  If
         size is not provided, it is computed from the max index found.
         """
-        if not isinstance(indices, (tuple, list)):
-            indices = tuple(indices)
-        if not isinstance(values, (tuple, list)):
-            values = tuple(values)
+        iarr = indices
+        varr = values
+        if not isinstance(iarr, np.ndarray):
+            if not isinstance(indices, (list, tuple)):
+                indices = tuple(indices)
+            iarr = np.array(indices)
+        if not isinstance(varr, np.ndarray):
+            if not isinstance(values, (list, tuple)):
+                values = tuple(values)
+            varr = np.array(values)
+
         if dtype is None:
-            if len(values) <= 0:
+            if len(varr) <= 0:
                 raise ValueError("No values provided. Unable to determine type.")
-            # Find dtype from any of the values (assumption is they are the same type)
-            dtype = type(values[0])
+            dtype = varr.dtype
+            if dtype == object:
+                raise ValueError(f"Unable to convert values to a usable dtype")
         dtype = lookup_dtype(dtype)
         # Compute size if not provided
         if size is None:
-            if not indices:
+            if len(iarr) <= 0:
                 raise ValueError("No indices provided. Unable to infer size.")
-            size = max(indices) + 1
+            size = int(iarr.max() + 1)
+        if len(iarr) > 0 and 'int' not in iarr.dtype.name:
+            raise ValueError(f"indices must be integers, not {iarr.dtype.name}")
         # Create the new vector
         w = cls.new(dtype, size, name=name)
         # Add the data
+        # This needs to be the original data to get proper error messages
         w.build(indices, values, dup_op=dup_op)
         return w
 

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -143,8 +143,10 @@ class Vector(BaseType):
         n[0] = self.nvals
         func = libget(f"GrB_Vector_extractTuples_{self.dtype.name}")
         check_status(func(indices, values, n, self.gb_obj[0]))
-        return (np.frombuffer(ffi.buffer(indices), dtype=np.uint64),
-                np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type))
+        return (
+            np.frombuffer(ffi.buffer(indices), dtype=np.uint64),
+            np.frombuffer(ffi.buffer(values), dtype=self.dtype.np_type)
+        )
 
     def build(self, indices, values, *, dup_op=None, clear=False, size=None):
         np_index = isinstance(indices, np.ndarray)
@@ -235,14 +237,14 @@ class Vector(BaseType):
                 raise ValueError("No values provided. Unable to determine type.")
             dtype = varr.dtype
             if dtype == object:
-                raise ValueError(f"Unable to convert values to a usable dtype")
+                raise ValueError("Unable to convert values to a usable dtype")
         dtype = lookup_dtype(dtype)
         # Compute size if not provided
         if size is None:
             if len(iarr) <= 0:
                 raise ValueError("No indices provided. Unable to infer size.")
             size = int(iarr.max() + 1)
-        if len(iarr) > 0 and 'int' not in iarr.dtype.name:
+        if len(iarr) > 0 and "int" not in iarr.dtype.name:
             raise ValueError(f"indices must be integers, not {iarr.dtype.name}")
         # Create the new vector
         w = cls.new(dtype, size, name=name)


### PR DESCRIPTION
Make `to_values` return a tuple of numpy arrays.
Make `from_values` and `build` accept numpy arrays as input.
Add "size" option to build, allowing it to function as a more effective rebuild.

Significant speed improvement for large objects.
```python
import numpy as np
import grblas

ni = np.arange(100000)
nv = np.ones(100000)
li = ni.tolist()
lv = nv.tolist()

# This takes 4.3 ms with the previous code
vec = grblas.Vector.from_values(li, lv)

# This takes 0.25 ms with the new code
vec = grblas.Vector.from_values(ni, nv)
```
Exporting using `to_values()` has a similar speedup.

Note that `from_values` with list or tuple input actually slowed down with the new code. I put in additional checks for datatypes.
