### PR TITLE
Support subassign with expected syntax `C[I, J](Mask) << A`

### DIFF
--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -39,7 +39,7 @@ def __getattr__(name):
             _load(name)
         return globals()[name]
     else:
-        raise AttributeError(f"module {__name__!r} has not attribute {name!r}")
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__():

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -32,11 +32,11 @@ def call(cfunc_name, args):
             f" - C signature: {sig}\n"
             f" - Error: {exc}"
         )
-    check_status(err_code)
+    rv = check_status(err_code)
     rec = _recorder.get(_prev_recorder)
     if rec is not None:
         rec.record(cfunc_name, args)
-    return err_code
+    return rv
 
 
 def _expect_type_message(

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -98,8 +98,11 @@ def _check_mask(mask, output=None):
         raise TypeError("Mask must indicate values (M.V) or structure (M.S)")
     if not isinstance(mask, Mask):
         raise TypeError(f"Invalid mask: {type(mask)}")
-    if output is not None and type(mask.mask) is not type(output):
-        raise TypeError(f"Mask object must be type {type(output)}; got {type(mask)}")
+    if output is not None:
+        from .vector import Vector
+
+        if type(output) is Vector and type(mask.mask) is not Vector:
+            raise TypeError(f"Mask object must be type Vector; got {type(mask.mask)}")
 
 
 class BaseType:
@@ -224,7 +227,10 @@ class BaseType:
                             scalar = Scalar.from_value(delayed, name=repr(delayed))
                         except TypeError:
                             raise TypeError(
-                                f"assignment value must be Expression object, not {type(delayed)}"
+                                "Assignment value must be a valid expression type, not "
+                                f"{type(delayed)}.\n\nValid expression types include "
+                                f"{type(self).__name__}, {type(self).__name__}Expression, "
+                                "AmbiguousAssignOrExtract, and scalars."
                             )
                     updater = self(mask=mask, accum=accum, replace=replace)
                     if type(self) is Matrix:

--- a/grblas/exceptions.py
+++ b/grblas/exceptions.py
@@ -80,19 +80,13 @@ _error_code_lookup = {
     lib.GrB_INDEX_OUT_OF_BOUNDS: IndexOutOfBound,
     lib.GrB_PANIC: Panic,
 }
-
-
-def is_error(response_code, error_class):
-    if response_code in _error_code_lookup:
-        if _error_code_lookup[response_code] == error_class:  # pragma: no branch
-            return True
-    return False
-
-
 GrB_SUCCESS = lib.GrB_SUCCESS
+GrB_NO_VALUE = lib.GrB_NO_VALUE
 
 
 def check_status(response_code):
     if response_code != GrB_SUCCESS:
+        if response_code == GrB_NO_VALUE:
+            return NoValue
         text = ffi.string(lib.GrB_error()).decode()
         raise _error_code_lookup[response_code](text)

--- a/grblas/mask.py
+++ b/grblas/mask.py
@@ -5,6 +5,11 @@ class Mask:
 
     def __init__(self, mask):
         self.mask = mask
+        from .matrix import Matrix
+        from .vector import Vector
+
+        if type(mask) not in {Matrix, Vector}:
+            raise TypeError(f"Mask value must be Matrix or Vector; got {type(mask)}")
 
     def __repr__(self):
         return self.mask.__repr__(mask=self)

--- a/grblas/mask.py
+++ b/grblas/mask.py
@@ -5,11 +5,6 @@ class Mask:
 
     def __init__(self, mask):
         self.mask = mask
-        from .matrix import Matrix
-        from .vector import Vector
-
-        if type(mask) not in {Matrix, Vector}:
-            raise TypeError(f"Mask value must be Matrix or Vector; got {type(mask)}")
 
     def __repr__(self):
         return self.mask.__repr__(mask=self)

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -719,7 +719,10 @@ class Matrix(BaseType):
                 if mask is not None and type(mask.mask) is Matrix:
                     if is_submask:
                         # C[i, J](M) << v
-                        raise TypeError("TODO")
+                        raise TypeError(
+                            "Indices for subassign imply Vector submask, "
+                            "but got Matrix mask instead"
+                        )
                     else:
                         # C(M)[i, J] << v
                         # Upcast v to a Matrix and use Matrix_assign
@@ -764,7 +767,10 @@ class Matrix(BaseType):
                 if mask is not None and type(mask.mask) is Matrix:
                     if is_submask:
                         # C[I, j](M) << v
-                        raise TypeError("TODO")
+                        raise TypeError(
+                            "Indices for subassign imply Vector submask, "
+                            "but got Matrix mask instead"
+                        )
                     else:
                         # C(M)[I, j] << v
                         # Upcast v to a Matrix and use Matrix_assign
@@ -944,11 +950,14 @@ class Matrix(BaseType):
                     if rowsize is None or colsize is None:
                         if rowsize is None and colsize is None:
                             # C[i, j](M) << c
-                            raise TypeError("TODO")
+                            raise TypeError("Single element assign does not accept a submask")
                         else:
                             # C[i, J](M) << c
                             # C[I, j](M) << c
-                            raise TypeError("TODO")
+                            raise TypeError(
+                                "Indices for subassign imply Vector submask, "
+                                "but got Matrix mask instead"
+                            )
                     # C[I, J](M) << c
                     # SS, SuiteSparse-specific: subassign
                     cfunc_name = f"GrB_Matrix_subassign_{value.dtype}"

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -138,10 +138,6 @@ class Scalar(BaseType):
 
     _nvals = nvals
 
-    @property
-    def _carg(self):
-        return self.gb_obj
-
     def dup(self, *, dtype=None, name=None):
         """Create a new Scalar by duplicating this one"""
         if dtype is None:

--- a/grblas/tests/conftest.py
+++ b/grblas/tests/conftest.py
@@ -1,4 +1,6 @@
+import grblas
 import atexit
+import itertools
 import pytest
 
 
@@ -6,7 +8,6 @@ def pytest_configure(config):
     backend = config.getoption("--backend", "suitesparse")
     blocking = config.getoption("--blocking", True)
     record = config.getoption("--record", False)
-    import grblas
 
     grblas.init(backend, blocking=blocking)
     print(f'Running tests with "{backend}" backend, blocking={blocking}, record={record}')
@@ -25,3 +26,11 @@ def pytest_configure(config):
 def pytest_runtest_setup(item):
     if "slow" in item.keywords and not item.config.getoption("--runslow", True):  # pragma: no cover
         pytest.skip("need --runslow option to run")
+
+
+@pytest.fixture(autouse=True, scope="function")
+def reset_name_counters():
+    """Reset automatic names for each test for easier comparison of record.txt"""
+    grblas.Matrix._name_counter = itertools.count()
+    grblas.Vector._name_counter = itertools.count()
+    grblas.Scalar._name_counter = itertools.count()

--- a/grblas/tests/test_core.py
+++ b/grblas/tests/test_core.py
@@ -33,3 +33,16 @@ def test_bad_libget():
 def test_lib_attrs():
     for attr in dir(grblas.lib):
         getattr(grblas.lib, attr)
+
+
+def test_bad_call():
+    class bad:
+        name = "bad"
+        _carg = 1
+
+    with pytest.raises(TypeError, match="Error calling GrB_Matrix_apply"):
+        grblas.base.call("GrB_Matrix_apply", [bad, bad, bad, bad, bad])
+    with pytest.raises(
+        TypeError, match=r"Call objects: GrB_Matrix_apply\(bad, bad, bad, bad, bad, bad\)"
+    ):
+        grblas.base.call("GrB_Matrix_apply", [bad, bad, bad, bad, bad, bad])

--- a/grblas/tests/test_formatting.py
+++ b/grblas/tests/test_formatting.py
@@ -27,7 +27,8 @@ def _printer(text, name, repr_name, indent):
                 # line = f"f'{{CSS_STYLE}}'"
                 in_style = False
                 is_style = True
-            else:
+            else:  # pragma: no cover
+                # This definitely gets covered, but why is it not picked up?
                 continue
         if repr_name == "repr_html" and line.startswith("<style>"):
             prev_line = prev_line[:-1]  # remove "\n"

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -149,14 +149,20 @@ def test_build(A):
 
 
 def test_extract_values(A):
-    rows, cols, vals = A.to_values()
+    rows, cols, vals = A.to_values(dtype=int)
     np.testing.assert_array_equal(rows, (0, 0, 1, 1, 2, 3, 3, 4, 5, 6, 6, 6))
     np.testing.assert_array_equal(cols, (1, 3, 4, 6, 5, 0, 2, 5, 2, 2, 3, 4))
     np.testing.assert_array_equal(vals, (2, 3, 8, 4, 1, 3, 3, 7, 1, 5, 7, 3))
-    Trows, Tcols, Tvals = A.T.to_values()
+    assert rows.dtype == np.uint64
+    assert cols.dtype == np.uint64
+    assert vals.dtype == np.int64
+    Trows, Tcols, Tvals = A.T.to_values(dtype=float)
     np.testing.assert_array_equal(rows, Tcols)
     np.testing.assert_array_equal(cols, Trows)
     np.testing.assert_array_equal(vals, Tvals)
+    assert Trows.dtype == np.uint64
+    assert Tcols.dtype == np.uint64
+    assert Tvals.dtype == np.float64
 
 
 def test_extract_element(A):
@@ -405,7 +411,7 @@ def test_subassign_row_col():
     )
     assert A.isequal(result1)
 
-    A[1, [1, 2]](m.V, accum=binary.plus) << v
+    A[1, [1, 2]](m.V, accum=binary.plus).update(v)
     result2 = Matrix.from_values(
         [0, 0, 0, 1, 1, 1, 2, 2, 2],
         [0, 1, 2, 0, 1, 2, 0, 1, 2],

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -564,6 +564,140 @@ def test_assign_row_scalar(A, v):
     assert C.isequal(result)
 
 
+def test_assign_row_col_matrix_mask():
+    # A         B       v1      v2
+    # 0 1       4 _     100     10
+    # 2 _       0 5             20
+    A = Matrix.from_values([0, 0, 1], [0, 1, 0], [0, 1, 2])
+    B = Matrix.from_values([0, 1, 1], [0, 0, 1], [4, 0, 5])
+    v1 = Vector.from_values([0], [100])
+    v2 = Vector.from_values([0, 1], [10, 20])
+
+    # row assign
+    C = A.dup()
+    C(B.S)[0, :] << v2
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [10, 1, 2])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, accum=binary.plus)[1, :] = v2
+    result = Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], [0, 1, 12, 20])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, replace=True)[1, :] << v2
+    result = Matrix.from_values([0, 1, 1], [0, 0, 1], [0, 10, 20])
+    assert C.isequal(result)
+
+    # col assign
+    C = A.dup()
+    C(B.S)[:, 0] = v2
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [10, 1, 20])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, accum=binary.plus)[:, 1] << v2
+    result = Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], [0, 1, 2, 20])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, replace=True)[:, 1] = v2
+    result = Matrix.from_values([0, 1, 1], [0, 0, 1], [0, 2, 20])
+    assert C.isequal(result)
+
+    # row assign scalar (as a sanity check)
+    C = A.dup()
+    C(B.S)[0, :] = 100
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 1, 2])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, accum=binary.plus)[1, :] << 100
+    result = Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], [0, 1, 102, 100])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, replace=True)[1, :] = 100
+    result = Matrix.from_values([0, 1, 1], [0, 0, 1], [0, 100, 100])
+    assert C.isequal(result)
+
+    # col assign scalar (as a sanity check)
+    C = A.dup()
+    C(B.S)[:, 0] << 100
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 1, 100])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, accum=binary.plus)[:, 1] = 100
+    result = Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], [0, 1, 2, 100])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C(B.S, replace=True)[:, 1] << 100
+    result = Matrix.from_values([0, 1, 1], [0, 0, 1], [0, 2, 100])
+    assert C.isequal(result)
+
+    # row subassign
+    C = A.dup()
+    C[0, :](v2.S) << v2
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [10, 20, 2])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C[0, [0]](v1.S) << v1
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 1, 2])
+    assert C.isequal(result)
+
+    with pytest.raises(TypeError, match="TODO"):
+        C[0, :](B.S) << v2
+
+    # col subassign
+    C = A.dup()
+    C[:, 0](v2.S) << v2
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [10, 1, 20])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C[[0], 0](v1.S) << v1
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 1, 2])
+    assert C.isequal(result)
+
+    with pytest.raises(TypeError, match="TODO"):
+        C[:, 0](B.S) << v2
+
+    # row subassign scalar
+    C = A.dup()
+    C[0, :](v2.S) << 100
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 100, 2])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C[0, [0]](v1.S) << 100
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 1, 2])
+    assert C.isequal(result)
+
+    with pytest.raises(TypeError, match="TODO"):
+        C[:, 0](B.S) << 100
+
+    # col subassign scalar
+    C = A.dup()
+    C[:, 0](v2.S) << 100
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 1, 100])
+    assert C.isequal(result)
+
+    C = A.dup()
+    C[[0], 0](v1.S) << 100
+    result = Matrix.from_values([0, 0, 1], [0, 1, 0], [100, 1, 2])
+    assert C.isequal(result)
+
+    with pytest.raises(TypeError, match="TODO"):
+        C[:, 0](B.S) << 100
+
+    # Bad subassign
+    with pytest.raises(TypeError, match="TODO"):
+        C[0, 0](B.S) << 100
+
+
 def test_assign_column_scalar(A, v):
     C = A.dup()
     C[:, 0](v.S) << v

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -388,6 +388,129 @@ def test_assign_row(A, v):
     assert C.isequal(result)
 
 
+def test_subassign_row_col():
+    A = Matrix.from_values(
+        [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        [0, 1, 2, 0, 1, 2, 0, 1, 2],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    )
+    m = Vector.from_values([1], [True])
+    v = Vector.from_values([0, 1], [10, 20])
+
+    A[[0, 1], 0](m.S) << v
+    result1 = Matrix.from_values(
+        [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        [0, 1, 2, 0, 1, 2, 0, 1, 2],
+        [0, 1, 2, 20, 4, 5, 6, 7, 8],
+    )
+    assert A.isequal(result1)
+
+    A[1, [1, 2]](m.V, accum=binary.plus) << v
+    result2 = Matrix.from_values(
+        [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        [0, 1, 2, 0, 1, 2, 0, 1, 2],
+        [0, 1, 2, 20, 4, 25, 6, 7, 8],
+    )
+    assert A.isequal(result2)
+
+    A[[0, 1], 0](m.S, binary.plus, replace=True) << v
+    result3 = Matrix.from_values(
+        [0, 0, 1, 1, 1, 2, 2, 2],
+        [1, 2, 0, 1, 2, 0, 1, 2],
+        [1, 2, 40, 4, 25, 6, 7, 8],
+    )
+    assert A.isequal(result3)
+
+    with pytest.raises(DimensionMismatch):
+        A(m.S)[[0, 1], 0] << v
+
+    A[[0, 1], 0](m.S) << 99
+    result4 = Matrix.from_values(
+        [0, 0, 1, 1, 1, 2, 2, 2],
+        [1, 2, 0, 1, 2, 0, 1, 2],
+        [1, 2, 99, 4, 25, 6, 7, 8],
+    )
+    assert A.isequal(result4)
+
+    A[[1, 2], 0](m.S, binary.plus, replace=True) << 100
+    result5 = Matrix.from_values(
+        [0, 0, 1, 1, 2, 2, 2],
+        [1, 2, 1, 2, 0, 1, 2],
+        [1, 2, 4, 25, 106, 7, 8],
+    )
+    assert A.isequal(result5)
+
+    A[2, [0, 1]](m.S) << -1
+    result6 = Matrix.from_values(
+        [0, 0, 1, 1, 2, 2, 2],
+        [1, 2, 1, 2, 0, 1, 2],
+        [1, 2, 4, 25, 106, -1, 8],
+    )
+    assert A.isequal(result6)
+
+
+def test_subassign_matrix():
+    A = Matrix.from_values(
+        [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        [0, 1, 2, 0, 1, 2, 0, 1, 2],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    )
+    m = Matrix.from_values([1], [0], [True])
+    v = Matrix.from_values([0, 1], [0, 0], [10, 20])
+    mT = m.T.new()
+
+    A[[0, 1], [0]](m.S) << v
+    result1 = Matrix.from_values(
+        [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        [0, 1, 2, 0, 1, 2, 0, 1, 2],
+        [0, 1, 2, 20, 4, 5, 6, 7, 8],
+    )
+    assert A.isequal(result1)
+
+    A[[1], [1, 2]](mT.V, accum=binary.plus) << v.T
+    result2 = Matrix.from_values(
+        [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        [0, 1, 2, 0, 1, 2, 0, 1, 2],
+        [0, 1, 2, 20, 4, 25, 6, 7, 8],
+    )
+    assert A.isequal(result2)
+
+    A[[0, 1], [0]](m.S, binary.plus, replace=True) << v
+    result3 = Matrix.from_values(
+        [0, 0, 1, 1, 1, 2, 2, 2],
+        [1, 2, 0, 1, 2, 0, 1, 2],
+        [1, 2, 40, 4, 25, 6, 7, 8],
+    )
+    assert A.isequal(result3)
+
+    with pytest.raises(DimensionMismatch):
+        A(m.S)[[0, 1], [0]] << v
+
+    A[[0, 1], [0]](m.S) << 99
+    result4 = Matrix.from_values(
+        [0, 0, 1, 1, 1, 2, 2, 2],
+        [1, 2, 0, 1, 2, 0, 1, 2],
+        [1, 2, 99, 4, 25, 6, 7, 8],
+    )
+    assert A.isequal(result4)
+
+    A[[1, 2], [0]](m.S, binary.plus, replace=True) << 100
+    result5 = Matrix.from_values(
+        [0, 0, 1, 1, 2, 2, 2],
+        [1, 2, 1, 2, 0, 1, 2],
+        [1, 2, 4, 25, 106, 7, 8],
+    )
+    assert A.isequal(result5)
+
+    A[[2], [0, 1]](mT.S) << -1
+    result6 = Matrix.from_values(
+        [0, 0, 1, 1, 2, 2, 2],
+        [1, 2, 1, 2, 0, 1, 2],
+        [1, 2, 4, 25, 106, -1, 8],
+    )
+    assert A.isequal(result6)
+
+
 def test_assign_column(A, v):
     result = Matrix.from_values(
         [3, 3, 5, 6, 0, 6, 1, 6, 2, 4, 1, 1, 3, 4, 6],
@@ -396,6 +519,74 @@ def test_assign_column(A, v):
     )
     C = A.dup()
     C[:, 1] = v
+    assert C.isequal(result)
+
+
+def test_assign_row_scalar(A, v):
+    C = A.dup()
+    C[0, :](v.S) << v
+    D = A.dup()
+    D(v.S)[0, :] << v
+    assert C.isequal(D)
+
+    C[:, :](C.S) << 1
+
+    with pytest.raises(
+        TypeError, match="Unable to use Vector mask on Matrix assignment to a Matrix"
+    ):
+        C[:, :](v.S) << 1
+    with pytest.raises(
+        TypeError, match="Unable to use Vector mask on single element assignment to a Matrix"
+    ):
+        C[0, 0](v.S) << 1
+
+    with pytest.raises(TypeError):
+        C[0, 0](v.S) << v
+    with pytest.raises(TypeError):
+        C(v.S)[0, 0] << v
+    with pytest.raises(TypeError):
+        C[0, 0](C.S) << v
+    with pytest.raises(TypeError):
+        C(C.S)[0, 0] << v
+
+    with pytest.raises(TypeError):
+        C[0, 0](v.S) << C
+    with pytest.raises(TypeError):
+        C[0, 0](C.S) << C
+
+    C = A.dup()
+    C(v.S)[0, :] = 10
+    result = Matrix.from_values(
+        [3, 0, 3, 5, 6, 0, 6, 1, 6, 2, 4, 1, 0, 0],
+        [0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6, 4, 6],
+        [3, 10, 3, 1, 5, 10, 7, 8, 3, 1, 7, 4, 10, 10],
+    )
+    assert C.isequal(result)
+
+
+def test_assign_column_scalar(A, v):
+    C = A.dup()
+    C[:, 0](v.S) << v
+    D = A.dup()
+    D(v.S)[:, 0] << v
+    assert C.isequal(D)
+
+    C = A.dup()
+    C[:, 1] = v
+    C(v.S)[:, 1] = 10
+    result = Matrix.from_values(
+        [3, 3, 5, 6, 0, 6, 1, 6, 2, 4, 1, 1, 3, 4, 6],
+        [0, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6, 1, 1, 1, 1],
+        [3, 3, 1, 5, 3, 7, 8, 3, 1, 7, 4, 10, 10, 10, 10],
+    )
+    assert C.isequal(result)
+
+    C(v.V, replace=True, accum=binary.plus)[:, 1] = 20
+    result = Matrix.from_values(
+        [3, 3, 5, 6, 0, 6, 1, 6, 2, 4, 1, 1, 3, 4],
+        [0, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6, 1, 1, 1],
+        [3, 3, 1, 5, 3, 7, 8, 3, 1, 7, 4, 30, 30, 30],
+    )
     assert C.isequal(result)
 
 
@@ -732,7 +923,7 @@ def test_no_equals(A):
 
 
 def test_bad_update(A):
-    with pytest.raises(TypeError, match="assignment value must be Expression"):
+    with pytest.raises(TypeError, match="Assignment value must be a valid expression"):
         A << None
 
 

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -8,6 +8,13 @@ from grblas import Vector, Matrix
 from grblas.ops import UnaryOp, BinaryOp, Monoid, Semiring
 
 
+def test_op_repr():
+    assert repr(unary.ainv) == "unary.ainv"
+    assert repr(binary.plus) == "binary.plus"
+    assert repr(monoid.times) == "monoid.times"
+    assert repr(semiring.plus_times) == "semiring.plus_times"
+
+
 def test_unaryop():
     assert unary.ainv["INT32"].gb_obj == lib.GrB_AINV_INT32
     assert unary.ainv[dtypes.UINT16].gb_obj == lib.GrB_AINV_UINT16

--- a/grblas/tests/test_recorder.py
+++ b/grblas/tests/test_recorder.py
@@ -1,12 +1,16 @@
 import grblas as gb
+from grblas.formatting import CSS_STYLE
 
 
 def test_recorder():
     A = gb.Matrix.from_values([0, 1], [1, 1], [1, 2], name="A")
     B = gb.Matrix.from_values([0, 1], [0, 1], [3, 4], name="B")
     with gb.Recorder() as rec:
+        assert rec.is_recording
         C = A.mxm(B).new(name="C")
+    assert not rec.is_recording
     with rec:
+        assert rec.is_recording
         rec.start()  # no-op
         D = A.mxm(B.T, gb.semiring.min_plus).new(name="D")
         C(D.S) << A.T.ewise_mult(B)
@@ -25,6 +29,96 @@ def test_recorder():
 
 def test_record_novalue():
     A = gb.Matrix.new(int, 3, 3, name="A")
-    with gb.Recorder() as rec:
-        A[0, 0].new(name="c")
+    rec = gb.Recorder(record=True)
+    A[0, 0].new(name="c")
     assert rec.data == ["GrB_Matrix_extractElement_INT64(&c, A, 0, 0);"]
+
+
+def test_record_repr():
+    A = gb.Matrix.new(int, 3, 3, name="A")
+    rec = gb.Recorder(record=True)
+    A[0, 0].new(name="c0")
+    assert repr(rec) == (
+        "grblas.Recorder (recording)\n"
+        "---------------------------\n"
+        "  GrB_Matrix_extractElement_INT64(&c0, A, 0, 0);"
+    )
+    rec.stop()
+    assert repr(rec) == (
+        "grblas.Recorder (not recording)\n"
+        "-------------------------------\n"
+        "  GrB_Matrix_extractElement_INT64(&c0, A, 0, 0);"
+    )
+    rec.start()
+    rec.max_rows = 10
+    for i in range(1, 20):
+        A[0, 0].new(name=f"c{i}")
+    assert repr(rec) == (
+        "grblas.Recorder (recording)\n"
+        "---------------------------\n"
+        "  GrB_Matrix_extractElement_INT64(&c0, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c1, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c2, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c3, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c4, A, 0, 0);\n"
+        "\n"
+        "  ... (10 rows not shown)\n"
+        "\n"
+        "  GrB_Matrix_extractElement_INT64(&c15, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c16, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c17, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c18, A, 0, 0);\n"
+        "  GrB_Matrix_extractElement_INT64(&c19, A, 0, 0);"
+    )
+
+
+def test_record_repr_markdown():
+    A = gb.Matrix.new(int, 3, 3, name="A")
+    rec = gb.Recorder()
+    rec.start()
+    A[0, 0].new(name="c")
+    assert rec._repr_markdown_() == (
+        "<div>\n"
+        f"{CSS_STYLE}\n"
+        '<details open class="gb-arg-details">\n'
+        '<summary class="gb-arg-summary">\n'
+        '<table class="gb-info-table" style="display: inline-block; vertical-align: middle;">\n'
+        "<tr><td>\n"
+        "<tt>grblas.Recorder</tt>\n"
+        '<div style="height: 12px; width: 12px; display: inline-block; vertical-align: middle; '
+        'margin-left: 2px; background-color: red; border-radius: 50%;"></div>\n'
+        "</td></tr>\n"
+        "</table>\n"
+        "</summary>\n"
+        '<blockquote class="gb-expr-blockquote" style="margin-left: -8px;">\n'
+        "\n"
+        "```C\n"
+        "  GrB_Matrix_extractElement_INT64(&c, A, 0, 0);\n"
+        "```\n"
+        "</blockquote>\n"
+        "</details>\n"
+        "</div>"
+    )
+    rec.stop()
+    assert rec._repr_markdown_() == (
+        "<div>\n"
+        f"{CSS_STYLE}\n"
+        '<details open class="gb-arg-details">\n'
+        '<summary class="gb-arg-summary">\n'
+        '<table class="gb-info-table" style="display: inline-block; vertical-align: middle;">\n'
+        "<tr><td>\n"
+        "<tt>grblas.Recorder</tt>\n"
+        '<div style="height: 12px; width: 12px; display: inline-block; vertical-align: middle; '
+        'margin-left: 2px; border-right: 5px solid gray; border-left: 5px solid gray;"></div>\n'
+        "</td></tr>\n"
+        "</table>\n"
+        "</summary>\n"
+        '<blockquote class="gb-expr-blockquote" style="margin-left: -8px;">\n'
+        "\n"
+        "```C\n"
+        "  GrB_Matrix_extractElement_INT64(&c, A, 0, 0);\n"
+        "```\n"
+        "</blockquote>\n"
+        "</details>\n"
+        "</div>"
+    )

--- a/grblas/tests/test_recorder.py
+++ b/grblas/tests/test_recorder.py
@@ -21,3 +21,10 @@ def test_recorder():
         "GrB_mxm(D, NULL, NULL, GxB_MIN_PLUS_INT64, A, B, GrB_DESC_T1);",
         "GrB_eWiseMult_Matrix_BinaryOp(C, D, NULL, GrB_TIMES_INT64, A, B, GrB_DESC_ST0);",
     ]
+
+
+def test_record_novalue():
+    A = gb.Matrix.new(int, 3, 3, name="A")
+    with gb.Recorder() as rec:
+        A[0, 0].new(name="c")
+    assert rec.data == ["GrB_Matrix_extractElement_INT64(&c, A, 0, 0);"]

--- a/grblas/tests/test_resolving.py
+++ b/grblas/tests/test_resolving.py
@@ -80,7 +80,7 @@ def test_updater_bad_types():
         v(mask=object())
     with pytest.raises(TypeError, match="Invalid mask"):
         v[[1, 2]].new(mask=object())
-    with pytest.raises(TypeError, match="Mask object must be type"):
+    with pytest.raises(TypeError, match="Mask object must be type Vector"):
         v.ewise_mult(v).new(mask=M.S)
     with pytest.raises(TypeError, match="Invalid"):
         v(object())
@@ -109,15 +109,15 @@ def test_updater_returns_updater():
 
 def test_updater_only_once():
     u = Vector.from_values([0, 1, 3], [1, 2, 3])
-    with pytest.raises(ValueError, match="already called.*no keywords"):
+    with pytest.raises(TypeError, match="'Assigner' object is not callable"):
         u()[0]()
-    with pytest.raises(ValueError, match="already called.*mask="):
+    with pytest.raises(TypeError, match="'Assigner' object is not callable"):
         u(mask=u.S)[0]()
-    with pytest.raises(ValueError, match="already called.*accum="):
+    with pytest.raises(TypeError, match="'Assigner' object is not callable"):
         u(accum=binary.plus)[0]()
     with pytest.raises(TypeError, match="not callable"):
         u()()
-    with pytest.raises(ValueError, match="already called.*no keywords"):
+    with pytest.raises(TypeError, match="'Assigner' object is not callable"):
         u[[0, 1]]()()
     # While we're at it...
     with pytest.raises(TypeError, match="is not subscriptable"):
@@ -131,15 +131,15 @@ def test_updater_only_once():
 def test_bad_extract_with_updater():
     u = Vector.from_values([0, 1, 3], [1, 2, 3])
     assert u[0].value == 1
-    with pytest.raises(TypeError, match="Cannot extract from an Updater"):
+    with pytest.raises(AttributeError, match="'Assigner' object has no attribute 'value'"):
         u(mask=u.S)[0].value
     with pytest.raises(AttributeError, match="Only Scalars"):
         u[[0, 1]].value
-    with pytest.raises(TypeError, match="Cannot extract from an Updater"):
+    with pytest.raises(AttributeError, match="'Assigner' object has no attribute 'new'"):
         u(mask=u.S)[0].new()
-    with pytest.raises(TypeError, match="Cannot extract from an Updater"):
+    with pytest.raises(TypeError, match="Assignment value must be a valid expression"):
         u << u(mask=u.S)[[1, 2]]
-    with pytest.raises(TypeError, match="Cannot extract from an Updater"):
+    with pytest.raises(TypeError, match="Assignment value must be a valid expression"):
         u << u()[[1, 2]]
     with pytest.raises(TypeError, match="mask is not allowed for single element extraction"):
         u[0].new(mask=u.S)
@@ -150,3 +150,13 @@ def test_bad_extract_with_updater():
         s()[0] = 1
     with pytest.raises(TypeError, match="Indexing not supported for Scalars"):
         s()[0]
+
+
+def test_updater_on_rhs():
+    u = Vector.from_values([0, 1, 3], [1, 2, 3])
+    with pytest.raises(TypeError, match="Assignment value must be a valid expression"):
+        u << u(replace=True)
+    with pytest.raises(TypeError, match="Assignment value must be a valid expression"):
+        u << u()
+    with pytest.raises(TypeError, match="Bad type for argument `value`"):
+        u[:] << u()

--- a/grblas/tests/test_scalar.py
+++ b/grblas/tests/test_scalar.py
@@ -177,6 +177,8 @@ def test_update(s):
         s(accum=binary.plus) << 6
     with pytest.raises(TypeError, match="Mask not allowed for Scalars"):
         s(s)
+    with pytest.raises(TypeError, match="input_mask not allowed for Scalars"):
+        s(input_mask=s)
 
 
 def test_not_hashable(s):

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -123,6 +123,20 @@ def test_extract_values(v):
     idx, vals = v.to_values()
     np.testing.assert_array_equal(idx, (1, 3, 4, 6))
     np.testing.assert_array_equal(vals, (1, 1, 2, 0))
+    assert idx.dtype == np.uint64
+    assert vals.dtype == np.int64
+
+    idx, vals = v.to_values(dtype=int)
+    np.testing.assert_array_equal(idx, (1, 3, 4, 6))
+    np.testing.assert_array_equal(vals, (1, 1, 2, 0))
+    assert idx.dtype == np.uint64
+    assert vals.dtype == np.int64
+
+    idx, vals = v.to_values(dtype=float)
+    np.testing.assert_array_equal(idx, (1, 3, 4, 6))
+    np.testing.assert_array_equal(vals, (1, 1, 2, 0))
+    assert idx.dtype == np.uint64
+    assert vals.dtype == np.float64
 
 
 def test_extract_element(v):

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -139,6 +139,22 @@ def test_extract_values(v):
     assert vals.dtype == np.float64
 
 
+def test_extract_input_mask():
+    v = Vector.from_values([0, 1, 2], [0, 1, 2])
+    m = Vector.from_values([0, 2], [0, 2])
+    result = v[[0, 1]].new(input_mask=m.S)
+    expected = Vector.from_values([0], [0], size=2)
+    assert result.isequal(expected)
+    # again
+    result.clear()
+    result(input_mask=m.S) << v[[0, 1]]
+    assert result.isequal(expected)
+    with pytest.raises(ValueError, match="Size of `input_mask` does not match size of input"):
+        v[[0, 2]].new(input_mask=expected.S)
+    with pytest.raises(TypeError, match="`input_mask` argument may only be used for extract"):
+        v(input_mask=m.S) << 1
+
+
 def test_extract_element(v):
     assert v[1].value == 1
     assert v[6].new() == 0
@@ -447,10 +463,10 @@ def test_assign_scalar_with_mask():
     result = Vector.from_values([0, 1, 2], [1, 2, 1100])
     assert v.isequal(result)
 
-    with pytest.raises(TypeError, match="TODO"):
+    with pytest.raises(TypeError, match="Single element assign does not accept a submask"):
         v[2](w1.S) << w1
 
-    with pytest.raises(TypeError, match="TODO"):
+    with pytest.raises(TypeError, match="Single element assign does not accept a submask"):
         v[2](w1.S) << 7
 
     v[[2]](w1.S) << 7

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -387,6 +387,34 @@ def test_assign_scalar_mask(v):
     assert w.isequal(result4)
 
 
+def test_subassign(A):
+    v = Vector.from_values([0, 1, 2], [0, 1, 2])
+    w = Vector.from_values([0, 1], [10, 20])
+    m = Vector.from_values([1], [True])
+    v[[0, 1]](m.S) << w
+    result1 = Vector.from_values([0, 1, 2], [0, 20, 2])
+    assert v.isequal(result1)
+    with pytest.raises(DimensionMismatch):
+        v[[0, 1]](v.S) << w
+    with pytest.raises(DimensionMismatch):
+        v[[0, 1]](m.S) << v
+
+    v[[0, 1]](m.S) << 100
+    result2 = Vector.from_values([0, 1, 2], [0, 100, 2])
+    assert v.isequal(result2)
+    with pytest.raises(DimensionMismatch):
+        v[[0, 1]](v.S) << 99
+    with pytest.raises(TypeError, match="Mask object must be type Vector"):
+        v[[0, 1]](A.S) << 88
+    with pytest.raises(TypeError, match="Mask object must be type Vector"):
+        v[[0, 1]](A.S) << w
+
+    # It may be nice for these to also raise
+    v[[0, 1]](A.S)
+    v[0](m.S)
+    v[0](replace=True)
+
+
 def test_apply(v):
     result = Vector.from_values([1, 3, 4, 6], [-1, -1, -2, 0])
     w = v.apply(unary.ainv).new()

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -415,6 +415,35 @@ def test_subassign(A):
     v[0](replace=True)
 
 
+def test_assign_scalar_with_mask():
+    v = Vector.from_values([0, 1, 2], [1, 2, 3])
+    m = Vector.from_values([0, 2], [False, True])
+    w1 = Vector.from_values([0], [50])
+    w3 = Vector.from_values([0, 1, 2], [10, 20, 30])
+
+    v(m.V)[:] << w3
+    result = Vector.from_values([0, 1, 2], [1, 2, 30])
+    assert v.isequal(result)
+
+    v(m.V)[:] << 100
+    result = Vector.from_values([0, 1, 2], [1, 2, 100])
+    assert v.isequal(result)
+
+    v(m.V, accum=binary.plus)[2] << 1000
+    result = Vector.from_values([0, 1, 2], [1, 2, 1100])
+    assert v.isequal(result)
+
+    with pytest.raises(TypeError, match="TODO"):
+        v[2](w1.S) << w1
+
+    with pytest.raises(TypeError, match="TODO"):
+        v[2](w1.S) << 7
+
+    v[[2]](w1.S) << 7
+    result = Vector.from_values([0, 1, 2], [1, 2, 7])
+    assert v.isequal(result)
+
+
 def test_apply(v):
     result = Vector.from_values([1, 3, 4, 6], [-1, -1, -2, 0])
     w = v.apply(unary.ainv).new()

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -530,7 +530,7 @@ class Vector(BaseType):
             if is_submask:
                 if isize is None:
                     # v[i](m) << w
-                    raise TypeError("TODO")
+                    raise TypeError("Single element assign does not accept a submask")
                 # v[I](m) << w
                 cfunc_name = "GrB_Vector_subassign"
                 expr_repr = "[[{2} elements]](%s) = {0.name}" % mask.name
@@ -553,7 +553,7 @@ class Vector(BaseType):
             if is_submask:
                 if isize is None:
                     # v[i](m) << c
-                    raise TypeError("TODO")
+                    raise TypeError("Single element assign does not accept a submask")
                 # v[I](m) << c
                 cfunc_name = f"GrB_Vector_subassign_{value.dtype}"
                 expr_repr = "[[{2} elements]](%s) = {0}" % mask.name

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -526,9 +526,15 @@ class Vector(BaseType):
         index, isize = resolved_indexes.indices[0]
         if type(value) is Vector:
             if is_submask:
+                if isize is None:
+                    # v[i](m) << w
+                    raise TypeError("TODO")
+                # v[I](m) << w
                 cfunc_name = "GrB_Vector_subassign"
                 expr_repr = "[[{2} elements]](%s) = {0.name}" % mask.name
             else:
+                # v(m)[I] << w
+                # v[I] << w
                 cfunc_name = "GrB_Vector_assign"
                 expr_repr = "[[{2} elements]] = {0.name}"
         else:
@@ -543,9 +549,18 @@ class Vector(BaseType):
                     extra_message="Literal scalars also accepted.",
                 )
             if is_submask:
+                if isize is None:
+                    # v[i](m) << c
+                    raise TypeError("TODO")
+                # v[I](m) << c
                 cfunc_name = f"GrB_Vector_subassign_{value.dtype}"
                 expr_repr = "[[{2} elements]](%s) = {0}" % mask.name
             else:
+                # v(m)[I] << c
+                # v[I] << c
+                if isize is None:
+                    index = _CArray([index.scalar.value])
+                    isize = _CScalar(1)
                 cfunc_name = f"GrB_Vector_assign_{value.dtype}"
                 expr_repr = "[[{2} elements]] = {0}"
         return VectorExpression(


### PR DESCRIPTION
Things became much simpler after introducing `Assigner`, which is the result of `C[I, J](Mask)` and `C(Mask)[I, J]` operations.  This was previously handled by `AmbiguousAssignOrExtract`.

This introduces SuiteSparse-specific functionality, and I note this in the code where appropriate.  The only recipes I needed to create were for assigning scalars for subassign to matrix row or column.

I flesh out some tests that were missing, such as `C(mask)[I, j] << v`.

I'm relying on CI to see if any notebooks need updated 🤞 

Oh, I should probably add something to the documentation (`README.md`).