### PR TITLE
Include `sys.prefix / "include"` in `include_dirs` when building extensions

### DIFF
--- a/grblas/backends/suitesparse/build.py
+++ b/grblas/backends/suitesparse/build.py
@@ -10,6 +10,7 @@ ffibuilder.set_source(
     "grblas.backends.suitesparse._suitesparse_grblas",
     r"""#include "GraphBLAS.h" """,
     libraries=["graphblas"],
+    include_dirs=[os.path.join(sys.prefix, "include")],
 )
 
 thisdir = os.path.dirname(__file__)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ except ImportError:
     use_cython = False
 import numpy as np
 import os
+import sys
 import versioneer
 
 define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
@@ -25,7 +26,7 @@ if use_cython:
 else:
     suffix = ".c"
 
-include_dirs = [np.get_include()]
+include_dirs = [np.get_include(), os.path.join(sys.prefix, "include")]
 ext_modules = [
     Extension(
         name[: -len(suffix)].replace("/", ".").replace("\\", "."),


### PR DESCRIPTION
These may be necessary on some systems to find "GraphBLAS.h", and it shouldn't hurt to add if they aren't necessary.