### PR TITLE
Include DLLs when building on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,10 @@ if use_cython:
 with open("README.md") as f:
     long_description = f.read()
 
+package_data = {"grblas": ["*/*.pyx", "*/*.pxd", "backends/suitesparse/*.h"]}
+if sys.platform == "win32":
+    package_data["grblas"].append("backends/suitesparse/*.dll")
+
 setup(
     name="grblas",
     version=versioneer.get_version(),
@@ -78,7 +82,7 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
     ],
-    package_data={"grblas": ["*/*.pyx", "*/*.pxd", "backends/suitesparse/*.h"]},
+    package_data=package_data,
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
I don't know if we should also do this if the platform is "cygwin".
Also, I don't want to worry about cross-platform compilation yet.