### PR TITLE
Don't allow expressions with `v[w]`; we don't support boolean maskig like numpy

### DIFF
--- a/grblas/base.py
+++ b/grblas/base.py
@@ -406,6 +406,15 @@ class BaseType:
     _expect_type = _expect_type
     _expect_op = _expect_op
 
+    # Don't let objects be coerced to numpy arrays
+    def __array__(self, *args, **kwargs):
+        raise TypeError(
+            f"{type(self).__name__} can't be directly converted to a numpy array; "
+            f"perhaps use `{self.name}.to_values()` method instead."
+        )
+
+    __array_struct__ = property(__array__)
+
 
 class BaseExpression:
     __slots__ = (

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -1214,6 +1214,8 @@ class TransposedMatrix:
     __iter__ = Matrix.__iter__
     _expect_type = Matrix._expect_type
     _expect_op = Matrix._expect_op
+    __array__ = Matrix.__array__
+    __array_struct__ = Matrix.__array_struct__
 
 
 expr.MatrixEwiseAddExpr.output_type = MatrixExpression

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -509,6 +509,15 @@ def test_extract_input_mask():
     assert result.isequal(expected)
 
 
+def test_extract_with_matrix(A):
+    with pytest.raises(TypeError, match="Invalid type for index"):
+        A[A.T, 1].new()
+    with pytest.raises(TypeError, match="Invalid type for index"):
+        A[A, [1]].new()
+    with pytest.raises(TypeError, match="Invalid type for index"):
+        A[[0], A.V].new()
+
+
 def test_assign(A):
     B = Matrix.from_values([0, 0, 1], [0, 1, 0], [9, 8, 7])
     result = Matrix.from_values(
@@ -528,6 +537,8 @@ def test_assign(A):
     C(C.S) << 1
     assert C.nvals == nvals
     assert C.reduce_scalar().value == nvals
+    with pytest.raises(TypeError, match="Invalid type for index"):
+        C[C, [1]] = C
 
 
 def test_assign_wrong_dims(A):
@@ -1700,3 +1711,12 @@ def test_weakref(A):
     expr = A.mxm(A)
     d["expr"] = expr
     assert d["expr"] is expr
+
+
+def test_not_to_array(A):
+    with pytest.raises(TypeError, match="Matrix can't be directly converted to a numpy array"):
+        np.array(A)
+    with pytest.raises(
+        TypeError, match="TransposedMatrix can't be directly converted to a numpy array"
+    ):
+        np.array(A.T)

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -350,6 +350,13 @@ def test_extract_array(v):
     assert w.isequal(result)
 
 
+def test_extract_with_vector(v):
+    with pytest.raises(TypeError, match="Invalid type for index"):
+        v[v].new()
+    with pytest.raises(TypeError, match="Invalid type for index"):
+        v[v.S].new()
+
+
 def test_extract_fancy_scalars(v):
     assert v.dtype == dtypes.INT64
     s = v[1].new()
@@ -392,6 +399,8 @@ def test_assign(v):
     assert w.isequal(result)
     with pytest.raises(TypeError):
         w[:] << u()
+    with pytest.raises(TypeError, match="Invalid type for index: Vector."):
+        w[w] = 1
 
 
 def test_assign_scalar(v):
@@ -853,3 +862,8 @@ def test_weakref(v):
     vS = v.S
     d["v.S"] = vS
     assert d["v.S"] is vS
+
+
+def test_not_to_array(v):
+    with pytest.raises(TypeError, match="Vector can't be directly converted to a numpy array"):
+        np.array(v)


### PR DESCRIPTION
Instead, use `mask=` keyword in the appropriate operation.
Also, for sanity, don't allow Vector, Matrix, or TransposedMatrix to be converted to numpy arrays.
Heads up: Some array creation semantics are changing in numpy 1.20.