### PR TITLE
Use `name=""` when creating scalars in operations to improve recording.

### DIFF
--- a/grblas/base.py
+++ b/grblas/base.py
@@ -337,7 +337,7 @@ class BaseType:
                         scalar = delayed
                     else:
                         try:
-                            scalar = Scalar.from_value(delayed, name=repr(delayed))
+                            scalar = Scalar.from_value(delayed, name="")
                         except TypeError:
                             raise TypeError(
                                 "Assignment value must be a valid expression type, not "

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -533,7 +533,7 @@ class Matrix(BaseType):
         elif right is None:
             if type(left) is not Scalar:
                 try:
-                    left = Scalar.from_value(left)
+                    left = Scalar.from_value(left, name="")
                 except TypeError:
                     self._expect_type(
                         left,
@@ -559,7 +559,7 @@ class Matrix(BaseType):
         elif left is None:
             if type(right) is not Scalar:
                 try:
-                    right = Scalar.from_value(right)
+                    right = Scalar.from_value(right, name="")
                 except TypeError:
                     self._expect_type(
                         right,
@@ -723,7 +723,7 @@ class Matrix(BaseType):
         col, _ = resolved_indexes.indices[1]
         if type(value) is not Scalar:
             try:
-                value = Scalar.from_value(value)
+                value = Scalar.from_value(value, name="")
             except TypeError:
                 self._expect_type(
                     value,
@@ -895,7 +895,7 @@ class Matrix(BaseType):
         else:
             if type(value) is not Scalar:
                 try:
-                    value = Scalar.from_value(value)
+                    value = Scalar.from_value(value, name="")
                 except TypeError:
                     if rowsize is None or colsize is None:
                         types = (Scalar, Vector)

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -259,7 +259,7 @@ class _CScalar:
 
     def __init__(self, scalar):
         if type(scalar) is not Scalar:
-            scalar = Scalar.from_value(scalar, name=repr(scalar), dtype=_INDEX)
+            scalar = Scalar.from_value(scalar, name="", dtype=_INDEX)
         self.scalar = scalar
         self.dtype = scalar.dtype
 

--- a/grblas/tests/test_recorder.py
+++ b/grblas/tests/test_recorder.py
@@ -35,6 +35,18 @@ def test_record_novalue():
     rec.stop()
 
 
+def test_record_scalars():
+    A = gb.Matrix.new(int, 3, 3, name="A")
+    with gb.Recorder() as rec:
+        A[0, 0] = 5
+        A.apply(gb.binary.lt, right=10).new(name="B")
+    assert list(rec) == [
+        "GrB_Matrix_setElement_INT64(A, 5, 0, 0);",
+        "GrB_Matrix_new(&B, GrB_BOOL, 3, 3);",
+        "GrB_Matrix_apply_BinaryOp2nd_INT64(B, NULL, NULL, GrB_LT_INT64, A, 10, NULL);",
+    ]
+
+
 def test_record_repr():
     A = gb.Matrix.new(int, 3, 3, name="A")
     rec = gb.Recorder(record=True)

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -432,7 +432,7 @@ class Vector(BaseType):
         elif right is None:
             if type(left) is not Scalar:
                 try:
-                    left = Scalar.from_value(left)
+                    left = Scalar.from_value(left, name="")
                 except TypeError:
                     self._expect_type(
                         left,
@@ -458,7 +458,7 @@ class Vector(BaseType):
         elif left is None:
             if type(right) is not Scalar:
                 try:
-                    right = Scalar.from_value(right)
+                    right = Scalar.from_value(right, name="")
                 except TypeError:
                     self._expect_type(
                         right,
@@ -543,7 +543,7 @@ class Vector(BaseType):
         index, _ = resolved_indexes.indices[0]
         if type(value) is not Scalar:
             try:
-                value = Scalar.from_value(value)
+                value = Scalar.from_value(value, name="")
             except TypeError:
                 self._expect_type(
                     value,
@@ -574,7 +574,7 @@ class Vector(BaseType):
         else:
             if type(value) is not Scalar:
                 try:
-                    value = Scalar.from_value(value)
+                    value = Scalar.from_value(value, name="")
                 except TypeError:
                     self._expect_type(
                         value,


### PR DESCRIPTION
If the name of a scalar is falsey, it will instead use the value of the scalar as the name.