### PR TITLE
Update to 5.0.3.  Includes changes that were part of the aggregator branch.

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         pyver: [3.7, 3.8, 3.9]
         testopts:
-          - "--blocking --record"
+          # - "--blocking --record"
+          - "--blocking"
           - "--non-blocking --record --runslow"
           # - "--backend=pygraphblas"  # Skip for now
         sourcetype:

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -121,7 +121,7 @@ jobs:
           source "$CONDA/etc/profile.d/conda.sh"
           conda config --set always_yes yes --set changeps1 no
           conda update -q conda
-          conda create -n coveralls_final -c conda-forge python=3.8 coveralls
+          conda create -n coveralls_final -c conda-forge python=3.9 coveralls
       - name: Coveralls Finished
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -82,7 +82,7 @@ jobs:
           # Make sure `from grblas import *` works as expected
           python -c "from grblas import * ; Matrix"
           # Make sure all top-level imports work
-          ( for attr in Matrix Scalar Vector Recorder backends base binary descriptor dtypes exceptions expr ffi formatting init io lib mask matrix monoid op operator scalar semiring tests unary vector recorder _ss ; do echo python -c \"from grblas import $attr\" ; if ! python -c "from grblas import $attr" ; then exit 1 ; fi ; done )
+          ( for attr in Matrix Scalar Vector Recorder backends base binary descriptor dtypes exceptions expr ffi formatting init io lib mask matrix monoid op operator scalar semiring tests unary vector recorder _ss ss ; do echo python -c \"from grblas import $attr\" ; if ! python -c "from grblas import $attr" ; then exit 1 ; fi ; done )
       - name: Unit tests
         if: (! contains(matrix.testopts, 'pygraphblas')) || (matrix.pyver != 3.9)
         run: |

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -17,11 +17,11 @@ jobs:
         pyver: [3.7, 3.8, 3.9]
         testopts:
           - "--blocking --record"
-          - "--backend=pygraphblas"
           - "--non-blocking --record --runslow"
+          # - "--backend=pygraphblas"  # Skip for now
         sourcetype:
           - "wheel"
-          # - "source"  # dope!  I broke it.
+          - "source"  # Is this still broken?
           - "upstream"
         exclude:
           - sourcetype: "upstream"

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -55,7 +55,7 @@ jobs:
           if [[ ${{ matrix.sourcetype }} == "wheel" ]]; then
               pip install suitesparse-graphblas
           else
-              conda install -c conda-forge graphblas
+              conda install -c conda-forge graphblas=5.0.3
           fi
           if [[ ${{ matrix.sourcetype }} == "source" ]]; then pip install --no-binary=all suitesparse-graphblas ; fi
           # I can't get pip install from git to work, so git clone instead.

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -16,19 +16,16 @@ jobs:
       matrix:
         pyver: [3.7, 3.8, 3.9]
         testopts:
-          # - "--blocking --record"
           - "--blocking"
           - "--non-blocking --record --runslow"
-          # - "--backend=pygraphblas"  # Skip for now
         sourcetype:
           - "wheel"
-          - "source"  # Is this still broken?
+          - "source"
           - "upstream"
+          - "conda-forge"
         exclude:
           - sourcetype: "upstream"
             testopts: "--non-blocking --record --runslow"
-          - sourcetype: "upstream"
-            testopts: "--backend=pygraphblas"
 
     steps:
       - name: Checkout
@@ -58,24 +55,27 @@ jobs:
           else
               conda install -c conda-forge graphblas=5.0.3
           fi
-          if [[ ${{ matrix.sourcetype }} == "source" ]]; then pip install --no-binary=all suitesparse-graphblas ; fi
-          # I can't get pip install from git to work, so git clone instead.
-          # pip install git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas
-          if [[ ${{ matrix.sourcetype }} == "upstream" ]]; then
+          if [[ ${{ matrix.sourcetype }} == "source" ]]; then
+              pip install --no-binary=all suitesparse-graphblas
+          elif [[ ${{ matrix.sourcetype }} == "upstream" ]]; then
+              # I can't get pip install from git to work, so git clone instead.
+              # pip install git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas
               conda install -c conda-forge cython
               git clone --depth=1 https://github.com/GraphBLAS/python-suitesparse-graphblas.git ssgb
               pushd ssgb
               python setup.py install
               popd
+          elif [[ ${{ matrix.sourcetype }} == "conda-forge" ]]; then
+              conda install -c conda-forge python-suitesparse-graphblas
           fi
           python setup.py build_ext -I $CONDA_PREFIX/include -L $CONDA_PREFIX/lib
           python setup.py develop
-      - name: Optional pygraphblas
-        if: contains(matrix.testopts, 'pygraphblas') && (matrix.pyver != 3.9)
-        run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate grblas
-          conda install -c conda-forge pygraphblas
+      # - name: Optional pygraphblas
+      #   if: contains(matrix.testopts, 'pygraphblas') && (matrix.pyver != 3.9)
+      #   run: |
+      #     source "$CONDA/etc/profile.d/conda.sh"
+      #     conda activate grblas
+      #     conda install -c conda-forge pygraphblas
       - name: Verify build
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
@@ -85,7 +85,7 @@ jobs:
           # Make sure all top-level imports work
           ( for attr in Matrix Scalar Vector Recorder backends base binary descriptor dtypes exceptions expr ffi formatting init io lib mask matrix monoid op operator scalar semiring tests unary vector recorder _ss ss ; do echo python -c \"from grblas import $attr\" ; if ! python -c "from grblas import $attr" ; then exit 1 ; fi ; done )
       - name: Unit tests
-        if: (! contains(matrix.testopts, 'pygraphblas')) || (matrix.pyver != 3.9)
+        # if: (! contains(matrix.testopts, 'pygraphblas')) || (matrix.pyver != 3.9)
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate grblas
@@ -94,7 +94,7 @@ jobs:
           coverage run -a --branch grblas/tests/test_auto_init.py
           coverage run -a --branch grblas/tests/test_external_init.py
       - name: Coverage
-        if: (! contains(matrix.testopts, 'pygraphblas')) || (matrix.pyver != 3.9)
+        # if: (! contains(matrix.testopts, 'pygraphblas')) || (matrix.pyver != 3.9)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: ${{ matrix.pyver}}/${{ matrix.testopts }}
@@ -105,7 +105,7 @@ jobs:
           coverage report --show-missing
           coveralls --service=github
       - name: Notebooks Execution check
-        if: (! contains(matrix.testopts, 'pygraphblas')) || (matrix.pyver != 3.9)
+        # if: (! contains(matrix.testopts, 'pygraphblas')) || (matrix.pyver != 3.9)
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate grblas

--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -53,7 +53,7 @@ def __getattr__(name):
     """Auto-initialize if special attrs used without explicit init call by user"""
     if name in _SPECIAL_ATTRS:
         if _init_params is None:
-            _init("suitesparse", True, automatic=True)
+            _init("suitesparse", False, automatic=True)
         if name not in globals():
             _load(name)
         return globals()[name]
@@ -70,17 +70,10 @@ def init(backend="suitesparse", blocking=False):
 
     Parameters
     ----------
-    backend : str, {"suitesparse", "pygraphblas"}
+    backend : str, one of {"suitesparse"}
     blocking : bool
         Whether to call GrB_init with GrB_BLOCKING or GrB_NONBLOCKING
 
-    The "pygraphblas" backend uses the pygraphblas Python package.
-    If this backend is chosen, then GrB_init is not called (we defer to pygraphblas)
-    and the `blocking` parameter is ignored.
-
-    Choosing "pygraphblas" allows objects to be converted between the two libraries.
-    Specifically, `Scalar`, `Vector`, and `Matrix` objects from `grblas` will now
-    have `to_pygraphblas` and `from_pygraphblas` methods.
     """
     _init(backend, blocking)
 
@@ -103,14 +96,7 @@ def _init(backend_arg, blocking, automatic=False):
         return
 
     backend = backend_arg
-    if backend == "pygraphblas":
-        import _pygraphblas, pygraphblas  # noqa
-
-        lib = _pygraphblas.lib
-        ffi = _pygraphblas.ffi
-        # I think pygraphblas is only non-blocking.
-        # Don't call GrB_init; defer to pygraphblas.
-    else:
+    if backend == "suitesparse":
         from suitesparse_graphblas import lib, ffi, initialize, is_initialized
 
         if is_initialized():
@@ -123,6 +109,8 @@ def _init(backend_arg, blocking, automatic=False):
                 )
         else:
             initialize(blocking=blocking)
+    else:
+        raise ValueError(f'Bad backend name.  Must be "suitesparse".  Got: {backend}')
     _init_params = passed_params
 
 

--- a/grblas/__init__.py
+++ b/grblas/__init__.py
@@ -45,6 +45,7 @@ _SPECIAL_ATTRS = {
     "tests",
     "utils",
     "_ss",
+    "ss",
 }
 
 

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -162,9 +162,11 @@ def normalize_chunks(chunks, shape):
     elif isinstance(chunks, np.ndarray):
         chunks = chunks.tolist()
     else:
-        raise TypeError("TODO")
+        raise TypeError(
+            f"chunks argument must be a list, tuple, or numpy array; got: {type(chunks)}"
+        )
     if len(chunks) != 2:
-        raise ValueError("TODO")
+        raise ValueError("chunks argument must be of length 2 (one for each dimension of a Matrix)")
     chunksizes = []
     for size, chunk in zip(shape, chunks):
         if chunk is None:
@@ -187,27 +189,40 @@ def normalize_chunks(chunks, shape):
                         raise ValueError(f"Chunksize must be greater than 0; got: {c}")
                 elif c is None:
                     if none_index is not None:
-                        raise TypeError("TODO")
+                        raise TypeError(
+                            'None value in chunks for "the rest" can only appear once per dimension'
+                        )
                     none_index = len(cur_chunks)
                     c = 0
                 elif c is not None:
-                    raise TypeError("TODO")
+                    raise TypeError(
+                        "Bad type for element in chunks; expected int or None, but got: "
+                        f"{type(chunks)}"
+                    )
                 cur_chunks.append(c)
             if none_index is not None:
                 fill = size - sum(cur_chunks)
                 if fill < 0:
-                    raise ValueError("TODO")
+                    raise ValueError(
+                        "Chunks are too large; None value in chunks would need to be negative "
+                        "to match size of input"
+                    )
                 cur_chunks[none_index] = fill
         elif isinstance(chunk, np.ndarray):
             if not np.issubdtype(chunk.dtype, np.integer):
-                raise TypeError("TODO")
+                raise TypeError(f"numpy array for chunks must be integer dtype; got {chunk.dtype}")
             if chunk.ndim != 1:
-                raise TypeError("TODO")
+                raise TypeError(
+                    f"numpy array for chunks must be 1-dimension; got ndim={chunk.ndim}"
+                )
             if (chunk < 0).any():
-                raise ValueError("TODO")
+                raise ValueError(f"Chunksize must be greater than 0; got: {chunk[chunk < 0]}")
             cur_chunks = chunk.tolist()
         else:
-            raise TypeError("TODO")
+            raise TypeError(
+                "Chunks for a dimension must be an integer, a list or tuple of integers, or None."
+                f"  Got: {type(chunk)}"
+            )
         chunksizes.append(cur_chunks)
     return chunksizes
 

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -148,13 +148,21 @@ def head(matrix, n=10, *, sort=False, dtype=None):
     return rows, cols, vals
 
 
-# 10                        -> ((10, 10), (10, 10))
-# (10, 10)                  -> ((10, 10), (10, 10))
-# (None, 10)                -> ((20,), (10, 10))
-# (10, (10, 10))            -> ((10, 10), (10, 10))
-# 15                        -> ((15, 5), (15, 5))
-# ((5, None), (None, 5))    -> ((5, 15), (15, 5))
 def normalize_chunks(chunks, shape):
+    """Normalize chunks argument for use by `Matrix.ss.split`.
+
+    Examples
+    --------
+    >>> shape = (10, 20)
+    >>> normalize_chunks(10, shape)
+    [(10,), (10, 10)]
+    >>> normalize_chunks((10, 10), shape)
+    [(10,), (10, 10)]
+    >>> normalize_chunks([None, (5, 15)], shape)
+    [(10,), (5, 15)]
+    >>> normalize_chunks((5, (5, None)), shape)
+    [(5, 5), (5, 15)]
+    """
     if isinstance(chunks, (list, tuple)):
         pass
     elif isinstance(chunks, Number):
@@ -228,6 +236,7 @@ def normalize_chunks(chunks, shape):
 
 
 def _concat_mn(tiles):
+    """Argument checking for `Matrix.ss.concat` and returns number of tiles in each dimension"""
     from ..matrix import Matrix
 
     if not isinstance(tiles, (list, tuple)):
@@ -330,6 +339,28 @@ class ss:
     def split(self, chunks, *, name=None):
         """
         GxB_Matrix_split
+
+        Split a Matrix into a 2D array of sub-matrices according to `chunks`.
+
+        This performs the opposite operation as ``concat``.
+
+        `chunks` is short for "chunksizes" and indicates the chunk sizes for each dimension.
+        `chunks` may be a single integer, or a length 2 tuple or list.  Example chunks:
+
+        - ``chunks=10``
+            - Split each dimension into chunks of size 10 (the last chunk may be smaller).
+        - ``chunks=(10, 20)``
+            - Split rows into chunks of size 10 and columns into chunks of size 20.
+        - ``chunks=(None, [5, 10])``
+            - Don't split rows into chunks, and split columns into two chunks of size 5 and 10.
+        ` ``chunks=(10, [20, None])``
+            - Split columns into two chunks of size 20 and ``ncols - 20``
+
+        See Also
+        --------
+        Matrix.ss.concat
+        grblas.ss.concat
+
         """
         from ..matrix import Matrix
 
@@ -387,6 +418,18 @@ class ss:
     def concat(self, tiles):
         """
         GxB_Matrix_concat
+
+        Concatenate a 2D list of Matrix objects into the current Matrix.
+        Any existing values in the current Matrix will be discarded.
+        To concatenate into a new Matrix, use `grblas.ss.concat`.
+
+        This performs the opposite operation as ``split``.
+
+        See Also
+        --------
+        Matrix.ss.split
+        grblas.ss.concat
+
         """
         m, n = _concat_mn(tiles)
         self._concat(tiles, m, n)

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -194,7 +194,7 @@ def normalize_chunks(chunks, shape):
                         )
                     none_index = len(cur_chunks)
                     c = 0
-                elif c is not None:
+                else:
                     raise TypeError(
                         "Bad type for element in chunks; expected int or None, but got: "
                         f"{type(chunks)}"
@@ -759,7 +759,7 @@ class ss:
         else:
             raise ValueError(f"Invalid format: {format}")
 
-        if is_uniform[0]:
+        if is_uniform[0]:  # pragma: no cover
             rv["is_uniform"] = True
         rv["format"] = format
         rv["values"] = values

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -388,8 +388,10 @@ class ss:
         for i, nrows in enumerate(tile_nrows):
             cur = []
             for j, ncols in enumerate(tile_ncols):
-                tile = Matrix(ffi.addressof(tiles, index), dtype, name=f"{name}_{i}x{j}")
-                tile._keepalive = tiles
+                # Copy to a new handle so we can free `tiles`
+                new_matrix = ffi.new("GrB_Matrix*")
+                new_matrix[0] = tiles[index]
+                tile = Matrix(new_matrix, dtype, name=f"{name}_{i}x{j}")
                 tile._nrows = nrows
                 tile._ncols = ncols
                 cur.append(tile)

--- a/grblas/_ss/vector.py
+++ b/grblas/_ss/vector.py
@@ -287,7 +287,7 @@ class ss:
         else:
             raise ValueError(f"Invalid format: {format}")
 
-        if is_uniform[0]:  # pragma: no cover
+        if is_uniform[0]:
             rv["is_uniform"] = True
         rv.update(
             format=format,

--- a/grblas/_ss/vector.py
+++ b/grblas/_ss/vector.py
@@ -287,7 +287,7 @@ class ss:
         else:
             raise ValueError(f"Invalid format: {format}")
 
-        if is_uniform[0]:
+        if is_uniform[0]:  # pragma: no cover
             rv["is_uniform"] = True
         rv.update(
             format=format,

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -1,3 +1,4 @@
+import numpy as np
 from contextvars import ContextVar
 from . import ffi, replace as replace_singleton
 from .descriptor import lookup as descriptor_lookup
@@ -406,14 +407,16 @@ class BaseType:
     _expect_type = _expect_type
     _expect_op = _expect_op
 
-    # Don't let objects be coerced to numpy arrays
-    def __array__(self, *args, **kwargs):
+    # Don't let non-scalars be coerced to numpy arrays
+    def __array__(self, dtype=None):
+        if self._is_scalar:
+            if dtype is None:
+                dtype = self.dtype.np_type
+            return np.array(self.value, dtype=dtype)
         raise TypeError(
             f"{type(self).__name__} can't be directly converted to a numpy array; "
             f"perhaps use `{self.name}.to_values()` method instead."
         )
-
-    __array_struct__ = property(__array__)
 
 
 class BaseExpression:

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -16,6 +16,12 @@ _recorder = ContextVar("recorder")
 _prev_recorder = None
 
 
+def record_raw(text):
+    rec = _recorder.get(_prev_recorder)
+    if rec is not None:
+        rec.record_raw(text)
+
+
 def call(cfunc_name, args):
     call_args = [getattr(x, "_carg", x) if x is not None else NULL for x in args]
     cfunc = libget(cfunc_name)

--- a/grblas/dtypes.py
+++ b/grblas/dtypes.py
@@ -1,4 +1,3 @@
-import re
 import numpy as np
 import numba
 from . import lib
@@ -163,9 +162,6 @@ def lookup_dtype(key):
     raise ValueError(f"Unknown dtype: {key}")
 
 
-_bits_pattern = re.compile(r"\D+(\d+)$")
-
-
 def unify(type1, type2):
     """
     Returns a type that can hold both type1 and type2
@@ -184,8 +180,8 @@ def unify(type1, type2):
     if type2 == BOOL:
         return type1
     # Compute bit numbers for comparison
-    num1 = int(_bits_pattern.match(type1.name).group(1))
-    num2 = int(_bits_pattern.match(type2.name).group(1))
+    num1 = 8 if type1.name[-1] == "8" else int(type1.name[-2:])
+    num2 = 8 if type2.name[-1] == "8" else int(type2.name[-2:])
 
     # Same type with different numbers is easy: choose the larger one
     if type1.name[1] == type2.name[1]:

--- a/grblas/dtypes.py
+++ b/grblas/dtypes.py
@@ -51,11 +51,12 @@ UINT16 = DataType("UINT16", lib.GrB_UINT16, "GrB_UINT16", "uint16_t", numba.type
 INT32 = DataType("INT32", lib.GrB_INT32, "GrB_INT32", "int32_t", numba.types.int32, np.int32)
 UINT32 = DataType("UINT32", lib.GrB_UINT32, "GrB_UINT32", "uint32_t", numba.types.uint32, np.uint32)
 INT64 = DataType("INT64", lib.GrB_INT64, "GrB_INT64", "int64_t", numba.types.int64, np.int64)
-UINT64 = DataType("UINT64", lib.GrB_UINT64, "GrB_UINT64", "uint64_t", numba.types.uint64, np.uint64)
 # _Index (like UINT64) is for internal use only and shouldn't be exposed to the user
 _INDEX = DataType("UINT64", lib.GrB_UINT64, "GrB_Index", "GrB_Index", numba.types.uint64, np.uint64)
+UINT64 = DataType("UINT64", lib.GrB_UINT64, "GrB_UINT64", "uint64_t", numba.types.uint64, np.uint64)
 FP32 = DataType("FP32", lib.GrB_FP32, "GrB_FP32", "float", numba.types.float32, np.float32)
 FP64 = DataType("FP64", lib.GrB_FP64, "GrB_FP64", "double", numba.types.float64, np.float64)
+
 if _supports_complex and hasattr(lib, "GxB_FC32"):  # pragma: no branch
     FC32 = DataType(
         "FC32", lib.GxB_FC32, "GxB_FC32", "float _Complex", numba.types.complex64, np.complex64
@@ -115,9 +116,12 @@ if _supports_complex:  # pragma: no branch
 
 for dtype in _dtypes_to_register:
     _registry[dtype.name] = dtype
+    _registry[dtype.name.lower()] = dtype
     _registry[dtype.gb_obj] = dtype
     _registry[dtype.gb_name] = dtype
+    _registry[dtype.gb_name.lower()] = dtype
     _registry[dtype.c_type] = dtype
+    _registry[dtype.c_type.upper()] = dtype
     _registry[dtype.numba_type] = dtype
     _registry[dtype.numba_type.name] = dtype
     val = _sample_values[dtype.name]
@@ -170,7 +174,7 @@ def unify(type1, type2):
     unify(INT32, INT64) -> INT64
     unify(INT8, UINT16) -> INT32
     unify(BOOL, UINT16) -> UINT16
-    unify(FP32, INT32) -> FP32
+    unify(FP32, INT32) -> FP64
     """
     if type1 == type2:
         return type1
@@ -182,12 +186,25 @@ def unify(type1, type2):
     # Compute bit numbers for comparison
     num1 = int(_bits_pattern.match(type1.name).group(1))
     num2 = int(_bits_pattern.match(type2.name).group(1))
-    # Floats anywhere requires floats
-    if type1.name[0] == "F" or type2.name[0] == "F":
-        return lookup_dtype(f"FP{max(num1, num2)}")
-    # Both ints or both uints is easy
-    if type1.name[0] == type2.name[0]:
+
+    # Same type with different numbers is easy: choose the larger one
+    if type1.name[1] == type2.name[1]:
         return type2 if num2 > num1 else type1
+    # One FC, one FP
+    if type1.name[0] == "F" and type2.name[0] == "F":
+        return lookup_dtype(f"FC{max(num1, num2)}")
+    # Float or complex with int
+    if type1.name[0] == "F":
+        maxnum = min(64, max(num1, 2 * num2))
+        if type1.name[1] == "C":
+            return lookup_dtype(f"FC{maxnum}")
+        return lookup_dtype(f"FP{maxnum}")
+    # Int with float or complex
+    if type2.name[0] == "F":
+        maxnum = min(64, max(2 * num1, num2))
+        if type2.name[1] == "C":
+            return lookup_dtype(f"FC{maxnum}")
+        return lookup_dtype(f"FP{maxnum}")
     # Mixed int/uint is a little harder
     # Need to double the uint bit number to safely store as int
     # Beyond 64, we have to move to float

--- a/grblas/exceptions.py
+++ b/grblas/exceptions.py
@@ -94,6 +94,8 @@ def check_status(response_code, args):
         arg = args[0]
     else:
         arg = args
+    if hasattr(arg, "_exc_arg"):
+        arg = arg._exc_arg
     if type(arg) is _Pointer:
         arg = arg.val
     type_name = type(arg).__name__

--- a/grblas/expr.py
+++ b/grblas/expr.py
@@ -76,6 +76,13 @@ class IndexerResolver:
                 raise TypeError(f"Invalid dtype for index: {index.dtype}")
             return _CArray(index), _CScalar(len(index))
         else:
+            from .scalar import Scalar
+
+            if typ is Scalar:
+                if index.dtype.name.startswith("F"):
+                    raise TypeError(f"An integer is required for indexing.  Got: {index.dtype}")
+                return _CScalar(index), None
+
             from .vector import Vector
             from .matrix import Matrix, TransposedMatrix
 

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -29,7 +29,7 @@ class Matrix(BaseType):
     High-level wrapper around GrB_Matrix type
     """
 
-    __slots__ = "_nrows", "_ncols", "ss", "_keepalive"
+    __slots__ = "_nrows", "_ncols", "ss"
     _is_transposed = False
     _name_counter = itertools.count()
 
@@ -38,7 +38,6 @@ class Matrix(BaseType):
             name = f"M_{next(Matrix._name_counter)}"
         self._nrows = None
         self._ncols = None
-        self._keepalive = None
         super().__init__(gb_obj, dtype, name)
         # Add ss extension methods
         self.ss = ss(self)

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -29,7 +29,7 @@ class Matrix(BaseType):
     High-level wrapper around GrB_Matrix type
     """
 
-    __slots__ = "_nrows", "_ncols", "ss"
+    __slots__ = "_nrows", "_ncols", "ss", "_keepalive"
     _is_transposed = False
     _name_counter = itertools.count()
 
@@ -38,6 +38,7 @@ class Matrix(BaseType):
             name = f"M_{next(Matrix._name_counter)}"
         self._nrows = None
         self._ncols = None
+        self._keepalive = None
         super().__init__(gb_obj, dtype, name)
         # Add ss extension methods
         self.ss = ss(self)

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -593,6 +593,7 @@ class Matrix(BaseType):
             ncols=self._ncols,
             expr_repr=expr_repr,
             at=self._is_transposed,
+            bt=self._is_transposed,
         )
 
     def reduce_rows(self, op=monoid.plus):
@@ -1215,7 +1216,6 @@ class TransposedMatrix:
     _expect_type = Matrix._expect_type
     _expect_op = Matrix._expect_op
     __array__ = Matrix.__array__
-    __array_struct__ = Matrix.__array_struct__
 
 
 expr.MatrixEwiseAddExpr.output_type = MatrixExpression

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -1021,9 +1021,9 @@ class Matrix(BaseType):
         col, _ = resolved_indexes.indices[1]
         call("GrB_Matrix_removeElement", [self, row, col])
 
-    if backend == "pygraphblas":
+    if backend == "suitesparse":
 
-        def to_pygraphblas(self):
+        def to_pygraphblas(self):  # pragma: no cover
             """Convert to a new `pygraphblas.Matrix`
 
             This does not copy data.
@@ -1038,7 +1038,7 @@ class Matrix(BaseType):
             return matrix
 
         @classmethod
-        def from_pygraphblas(cls, matrix):
+        def from_pygraphblas(cls, matrix):  # pragma: no cover
             """Convert a `pygraphblas.Matrix` to a new `grblas.Matrix`
 
             This does not copy data.
@@ -1046,6 +1046,10 @@ class Matrix(BaseType):
             This gives control of the underlying GraphBLAS object to `grblas`.
             This means operations on the original `pygraphblas` object will fail!
             """
+            import pygraphblas as pg
+
+            if not isinstance(matrix, pg.Matrix):
+                raise TypeError(f"Expected pygraphblas.Matrix object.  Got type: {type(matrix)}")
             dtype = lookup_dtype(matrix.gb_type)
             rv = cls(matrix.matrix, dtype)
             rv._nrows = matrix.nrows

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -1,4 +1,5 @@
 import inspect
+import itertools
 import re
 import numpy as np
 import numba
@@ -170,7 +171,7 @@ class TypedBuiltinSemiring(TypedOpBase):
         monoid_name, binary_name = self.name.split("_", 1)
         binop = getattr(binary, binary_name)[self.type]
         val = getattr(monoid, monoid_name)
-        if binop.return_type not in val.types and binary_name in {"land", "lor", "lxor"}:
+        if binop.return_type not in val.types and binary_name in {"land", "lor", "lxor", "lxnor"}:
             # e.g., with `plus_land`, `land` always returns a BOOL, but `plus` doesn't
             # operate on BOOL, so assume the return of `land` is coerced.
             return val[self.type]
@@ -378,7 +379,7 @@ class ParameterizedSemiring(ParameterizedUdf):
 
 
 class OpBase:
-    __slots__ = "name", "_typed_ops", "types", "_anonymous", "__weakref__"
+    __slots__ = "name", "_typed_ops", "types", "coercions", "_anonymous", "__weakref__"
     _parse_config = None
     _initialized = False
     _module = None
@@ -387,6 +388,7 @@ class OpBase:
         self.name = name
         self._typed_ops = {}
         self.types = {}
+        self.coercions = {}
         self._anonymous = anonymous
 
     def __repr__(self):
@@ -653,6 +655,45 @@ class UnaryOp(OpBase):
         if not hasattr(module, funcname):
             setattr(module, funcname, unary_op)
 
+    @classmethod
+    def _initialize(cls):
+        super()._initialize()
+        # Update type information with sane coercion
+        for names, *types in (
+            # fmt: off
+            (
+                (
+                    "erf", "erfc", "lgamma", "tgamma", "acos", "acosh", "asin", "asinh",
+                    "atan", "atanh", "ceil", "cos", "cosh", "exp", "exp2", "expm1", "floor",
+                    "log", "log10", "log1p", "log2", "round", "signum", "sin", "sinh", "sqrt",
+                    "tan", "tanh", "trunc",
+                ),
+                (("BOOL", "INT8", "INT16", "UINT8", "UINT16"), "FP32"),
+                (("INT32", "INT64", "UINT32", "UINT64"), "FP64"),
+            ),
+            (
+                ("positioni", "positioni1", "positionj", "positionj1"),
+                (
+                    (
+                        "BOOL", "FC32", "FC64", "FP32", "FP64", "INT8", "INT16",
+                        "UINT8", "UINT16", "UINT32", "UINT64",
+                    ),
+                    "INT64",
+                ),
+            ),
+            # fmt: on
+        ):
+            for name in names:
+                op = getattr(unary, name)
+                for input_types, target_type in types:
+                    typed_op = op._typed_ops[target_type]
+                    output_type = op.types[target_type]
+                    for dtype in input_types:
+                        if dtype not in op.types:
+                            op.types[dtype] = output_type
+                            op._typed_ops[dtype] = typed_op
+                            op.coercions[dtype] = target_type
+
     __call__ = TypedBuiltinUnaryOp.__call__
 
 
@@ -855,6 +896,54 @@ class BinaryOp(OpBase):
 
         BinaryOp.register_new("isclose", isclose, parameterized=True)
 
+        # Update type information with sane coercion
+        for names, *types in (
+            # fmt: off
+            (
+                ("atan2", "copysign", "fmod", "hypot", "ldexp", "remainder"),
+                (("BOOL", "INT8", "INT16", "UINT8", "UINT16"), "FP32"),
+                (("INT32", "INT64", "UINT32", "UINT64"), "FP64"),
+            ),
+            (
+                (
+                    "firsti", "firsti1", "firstj", "firstj1", "secondi", "secondi1",
+                    "secondj", "secondj1",),
+                (
+                    (
+                        "BOOL", "FC32", "FC64", "FP32", "FP64", "INT8", "INT16",
+                        "UINT8", "UINT16", "UINT32", "UINT64",
+                    ),
+                    "INT64",
+                ),
+            ),
+            (
+                ["lxnor"],
+                (
+                    (
+                        "FP32", "FP64", "INT8", "INT16", "INT32", "INT64",
+                        "UINT8", "UINT16", "UINT32", "UINT64",
+                    ),
+                    "BOOL",
+                ),
+            ),
+            (
+                ["cmplx"],
+                (("BOOL", "INT8", "INT16", "UINT8", "UINT16"), "FP32"),
+                (("INT32", "INT64", "UINT32", "UINT64"), "FP64"),
+            ),
+            # fmt: on
+        ):
+            for name in names:
+                op = getattr(binary, name)
+                for input_types, target_type in types:
+                    typed_op = op._typed_ops[target_type]
+                    output_type = op.types[target_type]
+                    for dtype in input_types:
+                        if dtype not in op.types:
+                            op.types[dtype] = output_type
+                            op._typed_ops[dtype] = typed_op
+                            op.coercions[dtype] = target_type
+
     def __init__(self, name, *, anonymous=False):
         super().__init__(name, anonymous=anonymous)
         self._monoid = None
@@ -959,6 +1048,40 @@ class Monoid(OpBase):
     @property
     def identities(self):
         return {dtype: val.identity for dtype, val in self._typed_ops.items()}
+
+    @classmethod
+    def _initialize(cls):
+        super()._initialize()
+        lor = monoid.lor._typed_ops["BOOL"]
+        land = monoid.land._typed_ops["BOOL"]
+        for cur_op, typed_op in [
+            (monoid.max, lor),
+            (monoid.min, land),
+            # (monoid.plus, lor),  # two choices: lor, or plus[int]
+            (monoid.times, land),
+        ]:
+            if "BOOL" not in cur_op.types:
+                cur_op.types["BOOL"] = "BOOL"
+                cur_op.coercions["BOOL"] = "BOOL"
+                cur_op._typed_ops["BOOL"] = typed_op
+
+        for cur_op in (monoid.lor, monoid.land, monoid.lxnor, monoid.lxor):
+            for dtype in (
+                "FP32",
+                "FP64",
+                "INT8",
+                "INT16",
+                "INT32",
+                "INT64",
+                "UINT8",
+                "UINT16",
+                "UINT32",
+                "UINT64",
+            ):
+                assert dtype not in cur_op.types
+                cur_op.types[dtype] = "BOOL"
+                cur_op.coercions[dtype] = "BOOL"
+                cur_op._typed_ops[dtype] = lor
 
     __call__ = TypedBuiltinMonoid.__call__
 
@@ -1087,6 +1210,83 @@ class Semiring(OpBase):
         for orig_name, orig in div_semirings.items():
             cls.register_new(f"{orig_name[:-3]}truediv", orig.monoid, binary.truediv)
             cls.register_new(f"{orig_name[:-3]}floordiv", orig.monoid, binary.floordiv)
+
+        # Update type information with sane coercion
+        for lname in ("any", "eq", "land", "lor", "lxnor", "lxor"):
+            target_name = f"{lname}_ne"
+            source_name = f"{lname}_lxor"
+            if not hasattr(semiring, target_name):
+                continue
+            target_op = getattr(semiring, target_name)
+            if "BOOL" not in target_op.types:
+                source_op = getattr(semiring, source_name)
+                typed_op = source_op._typed_ops["BOOL"]
+                target_op.types["BOOL"] = "BOOL"
+                target_op._typed_ops["BOOL"] = typed_op
+                target_op.coercions[dtype] = "BOOL"
+
+        for lnames, rnames, *types in (
+            # fmt: off
+            (
+                ("any", "max", "min", "plus", "times"),
+                (
+                    "firsti", "firsti1", "firstj", "firstj1",
+                    "secondi", "secondi1", "secondj", "secondj1",
+                ),
+                (
+                    (
+                        "BOOL", "FC32", "FC64", "FP32", "FP64", "INT8", "INT16",
+                        "UINT8", "UINT16", "UINT32", "UINT64",
+                    ),
+                    "INT64",
+                ),
+            ),
+            (
+                ("eq", "land", "lor", "lxnor", "lxor"),
+                ("first", "pair", "second"),
+                # TODO: check if FC coercion works here
+                (
+                    (
+                        "FC32", "FC64", "FP32", "FP64", "INT8", "INT16", "INT32", "INT64",
+                        "UINT8", "UINT16", "UINT32", "UINT64",
+                    ),
+                    "BOOL",
+                ),
+            ),
+            (
+                ("band", "bor", "bxnor", "bxor"),
+                ("band", "bor", "bxnor", "bxor"),
+                (["INT8"], "UINT16"),
+                (["INT16"], "UINT32"),
+                (["INT32"], "UINT64"),
+                (["INT64"], "UINT64"),
+            ),
+            (
+                ("any", "eq", "land", "lor", "lxnor", "lxor"),
+                ("eq", "land", "lor", "lxnor", "lxor", "ne"),
+                (
+                    (
+                        "FP32", "FP64", "INT8", "INT16", "INT32", "INT64",
+                        "UINT8", "UINT16", "UINT32", "UINT64",
+                    ),
+                    "BOOL",
+                ),
+            ),
+            # fmt: on
+        ):
+            for left, right in itertools.product(lnames, rnames):
+                name = f"{left}_{right}"
+                if not hasattr(semiring, name):
+                    continue
+                op = getattr(semiring, name)
+                for input_types, target_type in types:
+                    typed_op = op._typed_ops[target_type]
+                    output_type = op.types[target_type]
+                    for dtype in input_types:
+                        if dtype not in op.types:
+                            op.types[dtype] = output_type
+                            op._typed_ops[dtype] = typed_op
+                            op.coercions[dtype] = target_type
 
     def __init__(self, name, monoid=None, binaryop=None, *, anonymous=False):
         super().__init__(name, anonymous=anonymous)

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -939,7 +939,7 @@ class BinaryOp(OpBase):
                     typed_op = op._typed_ops[target_type]
                     output_type = op.types[target_type]
                     for dtype in input_types:
-                        if dtype not in op.types:
+                        if dtype not in op.types:  # pragma: no branch
                             op.types[dtype] = output_type
                             op._typed_ops[dtype] = typed_op
                             op.coercions[dtype] = target_type
@@ -1060,7 +1060,7 @@ class Monoid(OpBase):
             # (monoid.plus, lor),  # two choices: lor, or plus[int]
             (monoid.times, land),
         ]:
-            if "BOOL" not in cur_op.types:
+            if "BOOL" not in cur_op.types:  # pragma: no branch
                 cur_op.types["BOOL"] = "BOOL"
                 cur_op.coercions["BOOL"] = "BOOL"
                 cur_op._typed_ops["BOOL"] = typed_op
@@ -1218,7 +1218,7 @@ class Semiring(OpBase):
             if not hasattr(semiring, target_name):
                 continue
             target_op = getattr(semiring, target_name)
-            if "BOOL" not in target_op.types:
+            if "BOOL" not in target_op.types:  # pragma: no branch
                 source_op = getattr(semiring, source_name)
                 typed_op = source_op._typed_ops["BOOL"]
                 target_op.types["BOOL"] = "BOOL"

--- a/grblas/recorder.py
+++ b/grblas/recorder.py
@@ -72,6 +72,9 @@ class Recorder:
             base._prev_recorder = _recorder.get(self._prev_recorder)
         self._prev_recorder = None
 
+    def clear(self):
+        self.data.clear()
+
     def __enter__(self):
         self.start()
         return self

--- a/grblas/recorder.py
+++ b/grblas/recorder.py
@@ -58,6 +58,10 @@ class Recorder:
         self.data.append(f'{cfunc_name}({", ".join(gbstr(x) for x in args)});')
         base._prev_recorder = self
 
+    def record_raw(self, text):
+        self.data.append(text)
+        base._prev_recorder = self
+
     def start(self):
         if self._token is None:
             self._prev_recorder = _recorder.get(base._prev_recorder)

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -49,6 +49,16 @@ class Scalar(BaseType):
     def __int__(self):
         return int(self.value)
 
+    def __neg__(self):
+        dtype = self.dtype
+        if dtype.name[0] == "U" or dtype.name == "BOOL":
+            raise TypeError(f"The negative operator, `-`, is not supported for {dtype.name} dtype")
+        rv = Scalar.new(dtype, name=f"-{self.name}")
+        if self.is_empty:
+            return rv
+        rv.value = -self.value
+        return rv
+
     __index__ = __int__
 
     def isequal(self, other, *, check_dtype=False):
@@ -257,9 +267,9 @@ class _CScalar:
 
     __slots__ = "scalar", "dtype"
 
-    def __init__(self, scalar):
+    def __init__(self, scalar, dtype=_INDEX):
         if type(scalar) is not Scalar:
-            scalar = Scalar.from_value(scalar, name="", dtype=_INDEX)
+            scalar = Scalar.from_value(scalar, name="", dtype=dtype)
         self.scalar = scalar
         self.dtype = scalar.dtype
 

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -49,6 +49,9 @@ class Scalar(BaseType):
     def __int__(self):
         return int(self.value)
 
+    def __complex__(self):
+        return complex(self.value)
+
     def __neg__(self):
         dtype = self.dtype
         if dtype.name[0] == "U" or dtype.name == "BOOL":

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -200,9 +200,9 @@ class Scalar(BaseType):
     def _deserialize(value, dtype, name):
         return Scalar.from_value(value, dtype=dtype, name=name)
 
-    if backend == "pygraphblas":
+    if backend == "suitesparse":
 
-        def to_pygraphblas(self):
+        def to_pygraphblas(self):  # pragma: no cover
             """Convert to a new `pygraphblas.Scalar`
 
             This copies data.
@@ -212,11 +212,15 @@ class Scalar(BaseType):
             return pg.Scalar.from_value(self.value)
 
         @classmethod
-        def from_pygraphblas(cls, scalar):
+        def from_pygraphblas(cls, scalar):  # pragma: no cover
             """Convert a `pygraphblas.Scalar` to a new `grblas.Scalar`
 
             This copies data.
             """
+            import pygraphblas as pg
+
+            if not isinstance(scalar, pg.Scalar):
+                raise TypeError(f"Expected pygraphblas.Scalar object.  Got type: {type(scalar)}")
             dtype = lookup_dtype(scalar.gb_type)
             return cls.from_value(scalar[0], dtype)
 

--- a/grblas/ss.py
+++ b/grblas/ss.py
@@ -3,6 +3,7 @@ from .dtypes import INT64
 from .matrix import Matrix, TransposedMatrix
 from .scalar import Scalar
 from .vector import Vector
+from ._ss.matrix import _concat_mn
 
 
 class _grblas_ss:
@@ -55,4 +56,15 @@ def diag(x, k=0, *, dtype=None, name=None):
             size = 0
         rv = Vector.new(dtype, size=size, name=name)
         rv.ss.diag(x, k)
+    return rv
+
+
+def concat(tiles, *, dtype=None, name=None):
+    m, n = _concat_mn(tiles)
+    if dtype is None:
+        dtype = tiles[0][0].dtype
+    nrows = sum(row_tiles[0]._nrows for row_tiles in tiles)
+    ncols = sum(tile._ncols for tile in tiles[0])
+    rv = Matrix.new(dtype, nrows=nrows, ncols=ncols, name=name)
+    rv.ss._concat(tiles, m, n)
     return rv

--- a/grblas/ss.py
+++ b/grblas/ss.py
@@ -60,6 +60,20 @@ def diag(x, k=0, *, dtype=None, name=None):
 
 
 def concat(tiles, *, dtype=None, name=None):
+    """
+    GxB_Matrix_concat
+
+    Concatenate a 2D list of Matrix objects into a new Matrix.
+    To concatenate into an existing Matrix, use ``Matrix.ss.concat``.
+
+    This performs the opposite operation as ``split``.
+
+    See Also
+    --------
+    Matrix.ss.split
+    Matrix.ss.concat
+
+    """
     m, n = _concat_mn(tiles)
     if dtype is None:
         dtype = tiles[0][0].dtype

--- a/grblas/ss.py
+++ b/grblas/ss.py
@@ -1,0 +1,58 @@
+from .base import _expect_type
+from .dtypes import INT64
+from .matrix import Matrix, TransposedMatrix
+from .scalar import Scalar
+from .vector import Vector
+
+
+class _grblas_ss:
+    """Used in `_expect_type`"""
+
+
+_grblas_ss.__name__ = "grblas.ss"
+_grblas_ss = _grblas_ss()
+
+
+def diag(x, k=0, *, dtype=None, name=None):
+    """
+    GxB_Matrix_diag, GxB_Vector_diag
+
+    Extract a diagonal Vector from a Matrix, or construct a diagonal Matrix
+    from a Vector.  Unlike ``Matrix.diag`` and ``Vector.diag``, this function
+    returns a new object.
+
+    Parameters
+    ----------
+    x : Vector or Matrix
+        The Vector to assign to the diagonal, or the Matrix from which to
+        extract the diagonal.
+    k : int, default 0
+        Diagonal in question.  Use `k>0` for diagonals above the main diagonal,
+        and `k<0` for diagonals below the main diagonal.
+
+    See Also
+    --------
+    Vector.ss.diag
+    Matrix.ss.diag
+
+    """
+    _expect_type(_grblas_ss, x, (Matrix, TransposedMatrix, Vector), within="diag", argname="x")
+    if type(k) is not Scalar:
+        k = Scalar.from_value(k, dtype=INT64, name="")
+    if dtype is None:
+        dtype = x.dtype
+    typ = type(x)
+    if typ is Vector:
+        size = x._size + abs(k.value)
+        rv = Matrix.new(dtype, nrows=size, ncols=size, name=name)
+        rv.ss.diag(x, k)
+    else:
+        if k.value < 0:
+            size = min(x._nrows + k.value, x._ncols)
+        else:
+            size = min(x._ncols - k.value, x._nrows)
+        if size < 0:
+            size = 0
+        rv = Vector.new(dtype, size=size, name=name)
+        rv.ss.diag(x, k)
+    return rv

--- a/grblas/tests/test_auto_init.py
+++ b/grblas/tests/test_auto_init.py
@@ -2,6 +2,9 @@ if __name__ == "__main__":
     import pytest
     import grblas
 
+    with pytest.raises(ValueError, match="Bad backend name"):
+        grblas.init("bad_name")
+
     grblas.ffi
     grblas.matrix
     grblas.Matrix

--- a/grblas/tests/test_dtype.py
+++ b/grblas/tests/test_dtype.py
@@ -1,10 +1,11 @@
 import pytest
+import itertools
 import numpy as np
 import pickle
 from grblas import dtypes, lib
 from grblas.dtypes import lookup_dtype
 
-all_dtypes = (
+all_dtypes = [
     dtypes.BOOL,
     dtypes.INT8,
     dtypes.INT16,
@@ -16,7 +17,10 @@ all_dtypes = (
     dtypes.UINT64,
     dtypes.FP32,
     dtypes.FP64,
-)
+]
+if dtypes._supports_complex:
+    all_dtypes.append(dtypes.FC32)
+    all_dtypes.append(dtypes.FC64)
 
 
 def test_names():
@@ -92,8 +96,8 @@ def test_unify_dtypes():
     assert dtypes.unify(dtypes.INT16, dtypes.BOOL) == dtypes.INT16
     assert dtypes.unify(dtypes.INT16, dtypes.INT8) == dtypes.INT16
     assert dtypes.unify(dtypes.UINT32, dtypes.UINT8) == dtypes.UINT32
-    assert dtypes.unify(dtypes.UINT32, dtypes.FP32) == dtypes.FP32
-    assert dtypes.unify(dtypes.INT32, dtypes.FP32) == dtypes.FP32
+    assert dtypes.unify(dtypes.UINT32, dtypes.FP32) == dtypes.FP64
+    assert dtypes.unify(dtypes.INT32, dtypes.FP32) == dtypes.FP64
     assert dtypes.unify(dtypes.FP64, dtypes.UINT8) == dtypes.FP64
     assert dtypes.unify(dtypes.FP64, dtypes.FP32) == dtypes.FP64
     assert dtypes.unify(dtypes.INT16, dtypes.UINT16) == dtypes.INT32
@@ -129,3 +133,10 @@ def test_pickle():
     s = pickle.dumps(dtypes._INDEX)
     val2 = pickle.loads(s)
     assert dtypes._INDEX == val2
+
+
+def test_unify_matches_numpy():
+    for type1, type2 in itertools.product(all_dtypes, all_dtypes):
+        gb_type = dtypes.unify(type1, type2)
+        np_type = type(type1.np_type(0) + type2.np_type(0))
+        assert gb_type is lookup_dtype(np_type), f"({type1}, {type2}) -> {gb_type}"

--- a/grblas/tests/test_dtype.py
+++ b/grblas/tests/test_dtype.py
@@ -18,7 +18,7 @@ all_dtypes = [
     dtypes.FP32,
     dtypes.FP64,
 ]
-if dtypes._supports_complex:
+if dtypes._supports_complex:  # pragma: no branch
     all_dtypes.append(dtypes.FC32)
     all_dtypes.append(dtypes.FC64)
 

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1556,7 +1556,11 @@ def test_import_export_auto(A):
             A2 = A.dup() if give_ownership else A
             d = A2.ss.export(format, sort=sort, raw=raw, give_ownership=give_ownership)
             d["format"] = import_format
-            other = import_func(take_ownership=take_ownership, **d)
+            try:
+                other = import_func(take_ownership=take_ownership, **d)
+            except Exception:
+                print(dict(take_ownership=take_ownership, **d))
+                raise
             if (
                 format == "bitmapc"
                 and raw

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1724,3 +1724,30 @@ def test_not_to_array(A):
         TypeError, match="TransposedMatrix can't be directly converted to a numpy array"
     ):
         np.array(A.T)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (0, [], []),
+        (1, [0, 4], [2, 7]),
+        (3, [0, 1, 2], [3, 8, 1]),
+        (10, [], []),
+        (-1, [2], [3]),
+        (-3, [0, 2, 3], [3, 1, 7]),
+        (-10, [], []),
+    ],
+)
+def test_diag(A, params):
+    k, indices, values = params
+    expected = Vector.from_values(indices, values, dtype=A.dtype, size=max(0, A.nrows - abs(k)))
+    v = grblas.ss.diag(A, k=k)
+    assert expected.isequal(v)
+    v[:] = 0
+    v.ss.diag(A, k=k)
+    assert expected.isequal(v)
+    v = grblas.ss.diag(A.T, k=-k)
+    assert expected.isequal(v)
+    v[:] = 0
+    v.ss.diag(A.T, -k)
+    assert expected.isequal(v)

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1765,32 +1765,32 @@ def test_normalize_chunks():
     assert normalize_chunks([[5, None], (None, 6)], shape) == [[5, 15], [14, 6]]
     assert normalize_chunks(np.array([10, 10]), shape) == [[10, 10], [10, 10]]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="chunks argument must be a list"):
         normalize_chunks(None, shape)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="None value in chunks"):
         normalize_chunks([[5, 5, None, None], 10], shape)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="expected int or None, but got"):
         normalize_chunks([[15.5, 4.5], 10], shape)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Chunks for a dimension must be"):
         normalize_chunks([10, 10.5], shape)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="must be integer dtype; got float64"):
         normalize_chunks([10, np.array([1.5, 2.5])], shape)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="numpy array for chunks must be 1-dimension"):
         normalize_chunks([10, np.array([[1, 2], [3, 4]])], shape)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="hunks argument must be of length 2"):
         normalize_chunks([10], shape)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Chunksize must be greater than 0"):
         normalize_chunks(-10, shape)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Chunksize must be greater than 0"):
         normalize_chunks([-10, -10], shape)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Chunksize must be greater than 0"):
         normalize_chunks([[-10, 30], [-10, 30]], shape)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="chunks argument must be of length 2"):
         normalize_chunks([5, 5, 5], shape)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Chunks are too large"):
         normalize_chunks([[30, None], 10], shape)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Chunksize must be greater than 0"):
         normalize_chunks([10, np.array([-1, 2])], shape)
 
 

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1805,3 +1805,37 @@ def test_split(A):
                 assert expected.isequal(results[i][j])
     with pytest.raises(DimensionMismatch):
         A.ss.split([[5, 5], 3])
+
+
+def test_concat(A):
+    B1 = grblas.ss.concat([[A, A]], dtype=float)
+    assert B1.dtype == "FP64"
+    expected = Matrix.new(A.dtype, nrows=A.nrows, ncols=2 * A.ncols)
+    expected[:, : A.ncols] = A
+    expected[:, A.ncols :] = A
+    assert B1.isequal(expected)
+
+    B2 = Matrix.new(A.dtype, nrows=2 * A.nrows, ncols=A.ncols)
+    B2.ss.concat([[A], [A]])
+    expected = Matrix.new(A.dtype, nrows=2 * A.nrows, ncols=A.ncols)
+    expected[: A.nrows, :] = A
+    expected[A.nrows :, :] = A
+    assert B2.isequal(expected)
+
+    tiles = A.ss.split([4, 3])
+    A2 = grblas.ss.concat(tiles)
+    assert A2.isequal(A)
+
+    with pytest.raises(TypeError, match="tiles argument must be list or tuple"):
+        grblas.ss.concat(1)
+    with pytest.raises(TypeError, match="Each tile must be a Matrix"):
+        grblas.ss.concat([[A.T]])
+    with pytest.raises(TypeError, match="tiles must be lists or tuples"):
+        grblas.ss.concat([A])
+
+    with pytest.raises(ValueError, match="tiles argument must not be empty"):
+        grblas.ss.concat([])
+    with pytest.raises(ValueError, match="tiles must not be empty"):
+        grblas.ss.concat([[]])
+    with pytest.raises(ValueError, match="tiles must all be the same length"):
+        grblas.ss.concat([[A], [A, A]])

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1558,7 +1558,7 @@ def test_import_export_auto(A):
             d["format"] = import_format
             try:
                 other = import_func(take_ownership=take_ownership, **d)
-            except Exception:
+            except Exception:  # pragma: no cover
                 print(dict(take_ownership=take_ownership, **d))
                 raise
             if (
@@ -1796,11 +1796,12 @@ def test_normalize_chunks():
 
 def test_split(A):
     results = A.ss.split([4, 3])
-    row_boundaries = [0, 4, 7]
-    col_boundaries = [0, 3, 6, 7]
-    for i, (i1, i2) in enumerate(zip(row_boundaries[:-1], row_boundaries[1:])):
-        for j, (j1, j2) in enumerate(zip(col_boundaries[:-1], col_boundaries[1:])):
-            expected = A[i1:i2, j1:j2].new()
-            assert expected.isequal(results[i][j])
+    for results in [A.ss.split([4, 3]), A.ss.split([[4, None], 3], name="split")]:
+        row_boundaries = [0, 4, 7]
+        col_boundaries = [0, 3, 6, 7]
+        for i, (i1, i2) in enumerate(zip(row_boundaries[:-1], row_boundaries[1:])):
+            for j, (j1, j2) in enumerate(zip(col_boundaries[:-1], col_boundaries[1:])):
+                expected = A[i1:i2, j1:j2].new()
+                assert expected.isequal(results[i][j])
     with pytest.raises(DimensionMismatch):
         A.ss.split([[5, 5], 3])

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -8,6 +8,10 @@ from grblas import Vector, Matrix
 from grblas.operator import UnaryOp, BinaryOp, Monoid, Semiring
 
 
+def orig_types(op):
+    return op.types.keys() - op.coercions.keys()
+
+
 def test_op_repr():
     assert repr(unary.ainv) == "unary.ainv"
     assert repr(binary.plus) == "binary.plus"
@@ -18,15 +22,15 @@ def test_op_repr():
 def test_unaryop():
     assert unary.ainv["INT32"].gb_obj == lib.GrB_AINV_INT32
     assert unary.ainv[dtypes.UINT16].gb_obj == lib.GrB_AINV_UINT16
-    assert set(unary.positioni.types) == {"INT32", "INT64"}
-    assert set(unary.positionj1.types) == {"INT32", "INT64"}
+    assert orig_types(unary.positioni) == {"INT32", "INT64"}
+    assert orig_types(unary.positionj1) == {"INT32", "INT64"}
 
 
 def test_binaryop():
     assert binary.plus["INT32"].gb_obj == lib.GrB_PLUS_INT32
     assert binary.plus[dtypes.UINT16].gb_obj == lib.GrB_PLUS_UINT16
-    assert set(binary.firsti.types) == {"INT32", "INT64"}
-    assert set(binary.secondj1.types) == {"INT32", "INT64"}
+    assert orig_types(binary.firsti) == {"INT32", "INT64"}
+    assert orig_types(binary.secondj1) == {"INT32", "INT64"}
 
 
 def test_monoid():
@@ -37,7 +41,7 @@ def test_monoid():
 def test_semiring():
     assert semiring.min_plus["INT32"].gb_obj == lib.GrB_MIN_PLUS_SEMIRING_INT32
     assert semiring.min_plus[dtypes.UINT16].gb_obj == lib.GrB_MIN_PLUS_SEMIRING_UINT16
-    assert set(semiring.min_firsti.types) == {"INT32", "INT64"}
+    assert orig_types(semiring.min_firsti) == {"INT32", "INT64"}
 
 
 def test_find_opclass_unaryop():

--- a/grblas/tests/test_operator_types.py
+++ b/grblas/tests/test_operator_types.py
@@ -8,9 +8,9 @@ INT = frozenset({"INT8", "INT16", "INT32", "INT64", "UINT8", "UINT16", "UINT32",
 FP = frozenset({"FP32", "FP64"})
 FPINT = frozenset(FP | INT)
 NOFC = frozenset(BOOL | FPINT)
-if dtypes._supports_complex:  # pragma: no branch
+if dtypes._supports_complex:
     FC = frozenset({"FC32", "FC64"})
-else:
+else:  # pragma: no cover
     FC = frozenset()
 FCFP = frozenset(FC | FP)
 ALL = frozenset(NOFC | FC)

--- a/grblas/tests/test_operator_types.py
+++ b/grblas/tests/test_operator_types.py
@@ -47,7 +47,6 @@ BINARY = {
     },
     (INT, INT): {"band", "bclr", "bget", "bor", "bset", "bshift", "bxnor", "bxor"},
     (NOFC, BOOL): {"ge", "gt", "land", "le", "lor", "lt", "lxnor", "lxor"},
-    # (NOFC, BOOL): {"lxnor"},
     (NOFC, FC): {"cmplx"},
     (NOFC, FP): {"atan2", "copysign", "fmod", "hypot", "ldexp", "remainder"},
     (NOFC, FPINT): {"floordiv"},

--- a/grblas/tests/test_operator_types.py
+++ b/grblas/tests/test_operator_types.py
@@ -8,7 +8,7 @@ INT = frozenset({"INT8", "INT16", "INT32", "INT64", "UINT8", "UINT16", "UINT32",
 FP = frozenset({"FP32", "FP64"})
 FPINT = frozenset(FP | INT)
 NOFC = frozenset(BOOL | FPINT)
-if dtypes._supports_complex:
+if dtypes._supports_complex:  # pragma: no branch
     FC = frozenset({"FC32", "FC64"})
 else:
     FC = frozenset()
@@ -144,7 +144,7 @@ def _run_test(module, typ, expected):
         key = (frozenset(val.types.keys()), frozenset(val.types.values()))
         seen[key].add(name)
     seen = dict(seen)
-    if seen != expected:
+    if seen != expected:  # pragma: no cover
         seen_names = set()
         for names in seen.values():
             seen_names.update(names)

--- a/grblas/tests/test_operator_types.py
+++ b/grblas/tests/test_operator_types.py
@@ -1,0 +1,196 @@
+import itertools
+from collections import defaultdict
+from grblas import dtypes, unary, binary, monoid, semiring, operator
+
+BOOL = frozenset({"BOOL"})
+UINT = frozenset({"UINT8", "UINT16", "UINT32", "UINT64"})
+INT = frozenset({"INT8", "INT16", "INT32", "INT64", "UINT8", "UINT16", "UINT32", "UINT64"})
+FP = frozenset({"FP32", "FP64"})
+FPINT = frozenset(FP | INT)
+NOFC = frozenset(BOOL | FPINT)
+if dtypes._supports_complex:
+    FC = frozenset({"FC32", "FC64"})
+else:
+    FC = frozenset()
+FCFP = frozenset(FC | FP)
+ALL = frozenset(NOFC | FC)
+POS = frozenset({"INT32", "INT64"})
+NOBOOL = frozenset(ALL - BOOL)
+
+# fmt: off
+UNARY = {
+    (ALL, ALL): {"ainv", "identity", "minv", "one"},
+    (ALL, FCFP): {
+        "acos", "acosh", "asin", "asinh", "atan", "atanh", "ceil", "cos", "cosh", "exp",
+        "exp2", "expm1", "floor", "log", "log10", "log1p", "log2", "round", "signum",
+        "sin", "sinh", "sqrt", "tan", "tanh", "trunc",
+    },
+    (ALL, NOFC): {"abs"},
+    (ALL, POS): {"positioni", "positioni1", "positionj", "positionj1"},
+    (FCFP, BOOL): {"isfinite", "isinf", "isnan"},
+    (FC, FC): {"conj"},
+    (FC, FP): {"carg", "cimag", "creal"},
+    (FP, FP): {"frexpe", "frexpx"},
+    (INT, INT): {"bnot"},
+    (NOFC, FP): {"erf", "erfc", "lgamma", "tgamma"},
+    (NOFC, NOFC): {"lnot"},
+}
+BINARY = {
+    (ALL, ALL): {
+        "any", "cdiv", "first", "iseq", "isne", "minus", "pair", "plus", "pow", "rdiv",
+        "rminus", "second", "times",
+    },
+    (ALL, BOOL): {"eq", "ne"},
+    (ALL, FP): {"truediv"},
+    (ALL, POS): {
+        "firsti", "firsti1", "firstj", "firstj1", "secondi", "secondi1", "secondj", "secondj1",
+    },
+    (INT, INT): {"band", "bclr", "bget", "bor", "bset", "bshift", "bxnor", "bxor"},
+    (NOFC, BOOL): {"ge", "gt", "land", "le", "lor", "lt", "lxnor", "lxor"},
+    # (NOFC, BOOL): {"lxnor"},
+    (NOFC, FC): {"cmplx"},
+    (NOFC, FP): {"atan2", "copysign", "fmod", "hypot", "ldexp", "remainder"},
+    (NOFC, FPINT): {"floordiv"},
+    (NOFC, NOFC): {"isge", "isgt", "isle", "islt", "max", "min"},
+}
+MONOID = {
+    (UINT, UINT): {"band", "bor", "bxnor", "bxor"},
+    (BOOL, BOOL): {"eq"},
+    (NOFC, BOOL): {"land", "lor", "lxnor", "lxor"},  # others coerced to bool
+    (NOFC, NOFC): {"max", "min"},  # max[bool] -> lor, min[bool] -> land
+    (NOBOOL, NOBOOL): {"plus"},
+    (ALL, ALL): {"any", "times"},  # times[bool] -> land
+}
+
+_SEMIRING1 = {
+    (ALL, ALL): [
+        {"any"},
+        {"first", "pair", "second"},
+    ],
+    (ALL, FP): [
+        {"any", "max", "min", "plus", "times"},
+        {"truediv"},
+    ],
+    (ALL, POS): [  # POS, extra->INT64
+        {"any", "max", "min", "plus", "times"},
+        {"firsti", "firsti1", "firstj", "firstj1", "secondi", "secondi1", "secondj", "secondj1"},
+    ],
+    (ALL, BOOL): [  # BOOL, extra->BOOL
+        {"eq", "land", "lor", "lxnor", "lxor"},
+        {"first", "pair", "second"},
+    ],
+    (NOFC, BOOL): [  # BOOL, extra->BOOL, can't coerce FC here
+        # BOOL `*_ne` uses `*_lxor`
+        {"any", "eq", "land", "lor", "lxnor", "lxor"},
+        {"eq", "land", "lor", "lxor", "ne", "ge", "gt", "le", "lt"},
+    ],
+    (FPINT, FPINT): [
+        # Some of these are superseded by (ALL, ALL)
+        # We could cast BOOL to INT8
+        {"any", "max", "min", "plus", "times"},
+        {
+            "cdiv", "first", "iseq", "isge", "isgt", "isle", "islt", "isne", "land", "lor",
+            "lxor", "max", "min", "minus", "pair", "plus", "rdiv", "rminus", "second", "times",
+        },
+    ],
+    (INT, UINT): [  # signed int -> next larger unsigned int
+        {"band", "bor", "bxnor", "bxor"},
+        {"band", "bor", "bxnor", "bxor"},
+    ],
+    (NOBOOL, NOBOOL): [
+        # Some of these are superseded by (ALL, ALL)
+        # We could cast BOOL to INT8
+        {"any", "plus", "times"},
+        {"cdiv", "first", "minus", "pair", "plus", "pow", "rdiv", "rminus", "second", "times"},
+    ],
+    (NOFC, FPINT): [
+        {"any", "max", "min", "plus", "times"},
+        {"floordiv"},
+    ],
+    (NOFC, NOFC): [
+        {"any"},
+        {"land", "lor", "lxor"},
+    ],
+}
+# fmt: on
+_SEMIRING2 = defaultdict(lambda: (set(), set()))  # {semiring: [input_types, output_types]}
+for key, (leftvals, rightvals) in _SEMIRING1.items():
+    for left, right in itertools.product(leftvals, rightvals):
+        name = f"{left}_{right}"
+        if not hasattr(semiring, name):
+            continue
+        _SEMIRING2[name][0].update(key[0])
+        _SEMIRING2[name][1].update(key[1])
+
+SEMIRING = defaultdict(set)
+for name, (ins, outs) in _SEMIRING2.items():
+    SEMIRING[(frozenset(ins), frozenset(outs))].add(name)
+IGNORE = {
+    # UDFs created during tests
+    "is_positive",
+    "plus_one",
+    "bin_test_func",
+    "plus_plus_one",
+    "plus_plus_two",
+    "extra_twos",
+}
+
+
+def _run_test(module, typ, expected):
+    seen = defaultdict(set)
+    for name, val in vars(module).items():
+        if not isinstance(val, typ) or name in IGNORE:
+            continue
+        key = (frozenset(val.types.keys()), frozenset(val.types.values()))
+        seen[key].add(name)
+    seen = dict(seen)
+    if seen != expected:
+        seen_names = set()
+        for names in seen.values():
+            seen_names.update(names)
+        expected_names = set()
+        for names in expected.values():
+            expected_names.update(names)
+        extra = seen_names - expected_names
+        if extra:
+            raise AssertionError("grblas has more than expected:", sorted(extra))
+        missing = expected_names - seen_names
+        if missing:
+            raise AssertionError("grblas has less than expected:", sorted(missing))
+
+        for key in sorted(seen.keys() - expected.keys()):
+            print(
+                "Item not expected: (%s, %s): %s"
+                % (sorted(key[0]), sorted(key[1]), sorted(seen[key]))
+            )
+        for key in sorted(expected.keys() - seen.keys()):
+            print(
+                "Item expected, but not seen: (%s, %s): %s"
+                % (sorted(key[0]), sorted(key[1]), sorted(expected[key]))
+            )
+        for key in sorted(expected.keys() & seen.keys()):
+            if expected[key] != seen[key]:
+                print("Bad match:", sorted(key[0]), sorted(key[1]))
+                extra = seen[key] - expected[key]
+                if extra:
+                    print("    Extra:", sorted(extra))
+                missing = expected[key] - seen[key]
+                if missing:
+                    print("    Missing:", sorted(missing))
+        assert seen == expected
+
+
+def test_unarytypes():
+    _run_test(unary, operator.UnaryOp, UNARY)
+
+
+def test_binarytypes():
+    _run_test(binary, operator.BinaryOp, BINARY)
+
+
+def test_monoid_types():
+    _run_test(monoid, operator.Monoid, MONOID)
+
+
+def test_semiring_types():
+    _run_test(semiring, operator.Semiring, SEMIRING)

--- a/grblas/tests/test_pygraphblas.py
+++ b/grblas/tests/test_pygraphblas.py
@@ -1,8 +1,15 @@
+import pytest
 import grblas as gb
 
+try:
+    import pygraphblas as pg
+except ImportError:
+    pg = None
 
-def test_pygraphblas_matrix():
-    if gb.backend != "pygraphblas":
+
+@pytest.mark.skipif("not pg")
+def test_pygraphblas_matrix():  # pragma: no cover
+    if gb.backend != "suitesparse":  # pragma: no cover
         return
     import pygraphblas as pg
 
@@ -16,8 +23,9 @@ def test_pygraphblas_matrix():
     assert A.dtype == A2.dtype
 
 
-def test_pygraphblas_vector():
-    if gb.backend != "pygraphblas":
+@pytest.mark.skipif("not pg")
+def test_pygraphblas_vector():  # pragma: no cover
+    if gb.backend != "suitesparse":  # pragma: no cover
         return
     import pygraphblas as pg
 
@@ -31,8 +39,9 @@ def test_pygraphblas_vector():
     assert v.dtype == v2.dtype
 
 
-def test_pygraphblas_scalar():
-    if gb.backend != "pygraphblas":
+@pytest.mark.skipif("not pg")
+def test_pygraphblas_scalar():  # pragma: no cover
+    if gb.backend != "suitesparse":  # pragma: no cover
         return
     import pygraphblas as pg
 

--- a/grblas/tests/test_recorder.py
+++ b/grblas/tests/test_recorder.py
@@ -25,6 +25,8 @@ def test_recorder():
         "GrB_mxm(D, NULL, NULL, GrB_MIN_PLUS_SEMIRING_INT64, A, B, GrB_DESC_T1);",
         "GrB_Matrix_eWiseMult_BinaryOp(C, D, NULL, GrB_TIMES_INT64, A, B, GrB_DESC_ST0);",
     ]
+    rec.clear()
+    assert list(rec) == []
 
 
 def test_record_novalue():

--- a/grblas/tests/test_scalar.py
+++ b/grblas/tests/test_scalar.py
@@ -237,3 +237,22 @@ def test_scalar_to_numpy(s):
         np.testing.assert_array_equal(a, b)
         assert a.dtype == b.dtype
         assert a.shape == b.shape
+
+
+def test_neg():
+    for dtype in vars(dtypes).values():
+        if not isinstance(dtype, dtypes.DataType):
+            continue
+        s = Scalar.from_value(1, dtype=dtype)
+        empty = Scalar.new(dtype)
+        if dtype.name == "BOOL" or dtype.name.startswith("U"):
+            with pytest.raises(TypeError, match="The negative operator, `-`, is not supported"):
+                -s
+            with pytest.raises(TypeError, match="The negative operator, `-`, is not supported"):
+                -empty
+        else:
+            minus_s = Scalar.from_value(-1, dtype=dtype)
+            assert s == -minus_s
+            assert (-s).value == minus_s.value
+            assert empty == -empty
+            assert (-empty).value is None

--- a/grblas/tests/test_scalar.py
+++ b/grblas/tests/test_scalar.py
@@ -90,8 +90,12 @@ def test_equal(s):
 
 def test_casting(s):
     assert int(s) == 5
+    assert type(int(s)) is int
     assert float(s) == 5.0
+    assert type(float(s)) is float
     assert range(s) == range(5)
+    assert complex(s) == complex(5)
+    assert type(complex(s)) is complex
 
 
 def test_truthy(s):

--- a/grblas/tests/test_scalar.py
+++ b/grblas/tests/test_scalar.py
@@ -2,6 +2,7 @@ import pytest
 import grblas
 import pickle
 import weakref
+import numpy as np
 from grblas import Scalar
 from grblas import dtypes, binary
 from grblas.scalar import _CScalar
@@ -222,3 +223,17 @@ def test_weakref(s):
     d = weakref.WeakValueDictionary()
     d["s"] = s
     assert d["s"] is s
+
+
+def test_scalar_to_numpy(s):
+    for a, b in [
+        (np.array(s), np.array(5)),
+        (np.array(s, dtype=float), np.array(5.0)),
+        (np.array([s]), np.array([5])),
+        (np.array([s], dtype=float), np.array([5.0])),
+        (np.array([s, s]), np.array([5, 5])),
+        (np.array([s, s], dtype=float), np.array([5.0, 5.0])),
+    ]:
+        np.testing.assert_array_equal(a, b)
+        assert a.dtype == b.dtype
+        assert a.shape == b.shape

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -882,3 +882,20 @@ def test_vector_index_with_scalar():
         s = Scalar.from_value(1, dtype=dtype)
         with pytest.raises(TypeError, match="An integer is required for indexing"):
             v[s]
+
+
+def test_diag(v):
+    indices, values = v.to_values()
+    for k in range(-5, 5):
+        A = grblas.ss.diag(v, k=k)
+        size = v.size + abs(k)
+        rows = indices + max(0, -k)
+        cols = indices + max(0, k)
+        expected = Matrix.from_values(rows, cols, values, nrows=size, ncols=size, dtype=v.dtype)
+        assert expected.isequal(A)
+        w = grblas.ss.diag(A, k)
+        assert v.isequal(w)
+        assert w.dtype == "INT64"
+        w = grblas.ss.diag(A.T, -k, dtype=float)
+        assert v.isequal(w)
+        assert w.dtype == "FP64"

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -867,3 +867,18 @@ def test_weakref(v):
 def test_not_to_array(v):
     with pytest.raises(TypeError, match="Vector can't be directly converted to a numpy array"):
         np.array(v)
+
+
+def test_vector_index_with_scalar():
+    v = Vector.from_values([0, 1, 2], [10, 20, 30])
+    expected = Vector.from_values([0, 1], [20, 10])
+    for dtype in ["bool", "int8", "uint8", "int16", "uint16", "int32", "uint32"]:
+        s1 = Scalar.from_value(1, dtype=dtype)
+        assert v[s1] == 20
+        s0 = Scalar.from_value(0, dtype=dtype)
+        w = v[[s1, s0]].new()
+        assert w.isequal(expected)
+    for dtype in ["fp32", "fp64", "fc32", "fc64"]:
+        s = Scalar.from_value(1, dtype=dtype)
+        with pytest.raises(TypeError, match="An integer is required for indexing"):
+            v[s]

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -893,7 +893,7 @@ def test_diag(v):
         cols = indices + max(0, k)
         expected = Matrix.from_values(rows, cols, values, nrows=size, ncols=size, dtype=v.dtype)
         assert expected.isequal(A)
-        w = grblas.ss.diag(A, k)
+        w = grblas.ss.diag(A, Scalar.from_value(k))
         assert v.isequal(w)
         assert w.dtype == "INT64"
         w = grblas.ss.diag(A.T, -k, dtype=float)

--- a/grblas/utils.py
+++ b/grblas/utils.py
@@ -35,7 +35,7 @@ def ints_to_numpy_buffer(array, dtype, *, name="array", copy=False, ownable=Fals
         raise ValueError(f"{name} must be integers, not {array.dtype.name}")
     array = np.array(array, dtype, copy=copy, order=order)
     if ownable and (not array.flags.owndata or not array.flags.writeable):
-        array = array.copy()
+        array = array.copy(order)
     return array
 
 
@@ -53,7 +53,7 @@ def values_to_numpy_buffer(array, dtype=None, *, copy=False, ownable=False, orde
             array = array.astype(np.int64)
         dtype = lookup_dtype(array.dtype)
     if ownable and (not array.flags.owndata or not array.flags.writeable):
-        array = array.copy()
+        array = array.copy(order)
     return array, dtype
 
 

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -498,7 +498,7 @@ class Vector(BaseType):
         Reduce all values into a scalar
         Default op is monoid.lor for boolean and monoid.plus otherwise
         """
-        method_name = "reduce_scalar"
+        method_name = "reduce"
         op = get_typed_op(op, self.dtype)
         if op.opclass == "BinaryOp" and op.monoid is not None:
             op = op.monoid

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -612,9 +612,9 @@ class Vector(BaseType):
         index, _ = resolved_indexes.indices[0]
         call("GrB_Vector_removeElement", [self, index])
 
-    if backend == "pygraphblas":
+    if backend == "suitesparse":
 
-        def to_pygraphblas(self):
+        def to_pygraphblas(self):  # pragma: no cover
             """Convert to a new `pygraphblas.Vector`
 
             This does not copy data.
@@ -629,7 +629,7 @@ class Vector(BaseType):
             return vector
 
         @classmethod
-        def from_pygraphblas(cls, vector):
+        def from_pygraphblas(cls, vector):  # pragma: no cover
             """Convert a `pygraphblas.Vector` to a new `grblas.Vector`
 
             This does not copy data.
@@ -637,6 +637,10 @@ class Vector(BaseType):
             This gives control of the underlying GraphBLAS object to `grblas`.
             This means operations on the original `pygraphblas` object will fail!
             """
+            import pygraphblas as pg
+
+            if not isinstance(vector, pg.Vector):
+                raise TypeError(f"Expected pygraphblas.Vector object.  Got type: {type(vector)}")
             dtype = lookup_dtype(vector.gb_type)
             rv = cls(vector.vector, dtype)
             rv._size = vector.size


### PR DESCRIPTION
- Allow Scalars to be used in indexing
- Allow Scalars to be used to construct numpy arrays
- Fix SuiteSparse bug in Matrix apply1st and apply2nd (but now fixed in SS 5.0.3)
- Fix dtypes.unity for complex numbers (all pairs now match numpy behavior)
- Add sane coercions to operators (such as `exp(1)`)