### PR TITLE
Optimization: use cached `_value` `expr.new()` if possible

### DIFF
--- a/grblas/base.py
+++ b/grblas/base.py
@@ -502,8 +502,6 @@ class BaseExpression:
         self._value = None
 
     def new(self, *, dtype=None, mask=None, name=None):
-        if dtype is not None:
-            dtype = lookup_dtype(dtype)
         if (
             mask is None
             and self._value is not None

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -502,6 +502,18 @@ class BaseExpression:
         self._value = None
 
     def new(self, *, dtype=None, mask=None, name=None):
+        if dtype is not None:
+            dtype = lookup_dtype(dtype)
+        if (
+            mask is None
+            and self._value is not None
+            and (dtype is None or self._value.dtype == dtype)
+        ):
+            rv = self._value
+            if name is not None:
+                rv.name = name
+            self._value = None
+            return rv
         output = self.construct_output(dtype=dtype, name=name)
         if mask is None:
             output.update(self)

--- a/grblas/expr.py
+++ b/grblas/expr.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from . import lib, utils
-from .dtypes import lookup_dtype
 from .utils import _CArray, output_type
 
 
@@ -344,8 +343,6 @@ class InfixExprBase:
         self._value = None
 
     def new(self, *, dtype=None, mask=None, name=None):
-        if dtype is not None:
-            dtype = lookup_dtype(dtype)
         if (
             mask is None
             and self._value is not None

--- a/grblas/expr.py
+++ b/grblas/expr.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from . import lib, utils
+from .dtypes import lookup_dtype
 from .utils import _CArray, output_type
 
 
@@ -343,6 +344,18 @@ class InfixExprBase:
         self._value = None
 
     def new(self, *, dtype=None, mask=None, name=None):
+        if dtype is not None:
+            dtype = lookup_dtype(dtype)
+        if (
+            mask is None
+            and self._value is not None
+            and (dtype is None or self._value.dtype == dtype)
+        ):
+            rv = self._value
+            if name is not None:
+                rv.name = name
+            self._value = None
+            return rv
         # Rely on the default operator for the method
         expr = getattr(self.left, self.method_name)(self.right)
         return expr.new(dtype=dtype, mask=mask, name=name)

--- a/grblas/tests/test_infix.py
+++ b/grblas/tests/test_infix.py
@@ -37,6 +37,7 @@ def test_ewise(v1, v2, A1, A2):
         (A1, A1),
     ]:
         expected = left.ewise_mult(right, monoid.times).new()
+        assert expected.isequal((left & right).new(dtype=float))
         assert expected.isequal(monoid.times(left & right).new())
         assert expected.isequal(monoid.times[float](left & right).new())
         assert expected.isequal((left & right).new())  # use `left.ewise_mult` default op

--- a/grblas/tests/test_infix.py
+++ b/grblas/tests/test_infix.py
@@ -37,6 +37,10 @@ def test_ewise(v1, v2, A1, A2):
         (A1, A1),
     ]:
         expected = left.ewise_mult(right, monoid.times).new()
+        expr = left & right
+        assert expr.nvals == expected.nvals
+        val = expr.new(name="val")
+        assert val.name == "val"
         assert expected.isequal((left & right).new(dtype=float))
         assert expected.isequal(monoid.times(left & right).new())
         assert expected.isequal(monoid.times[float](left & right).new())

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1076,6 +1076,9 @@ def test_auto(v):
         assert expr.nvals == expected.nvals
         assert expr._nvals == expected._nvals
         assert expr.isclose(expected)
+        val = expr.new(name="val")
+        assert val.name == "val"
+        assert expr._value is None
         assert expected.isclose(expr)
         assert expr.isequal(expected)
         assert expected.isequal(expr)


### PR DESCRIPTION
The cached `_value` should be read-only and, hence, valid to return from `.new()`.