### PR TITLE
Use `_VectorAsMatrix` in `C(M.S)[row, cols] << v` to avoid copy

### DIFF
--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -20,7 +20,7 @@ from .utils import (
     values_to_numpy_buffer,
     wrapdoc,
 )
-from .vector import Vector, VectorExpression
+from .vector import Vector, VectorExpression, _VectorAsMatrix
 
 ffi_new = ffi.new
 
@@ -797,18 +797,15 @@ class Matrix(BaseType):
                         # Upcast v to a Matrix and use Matrix_assign
                         rows = _CArray([rows.scalar.value])
                         rowsize = _CScalar(1)
-                        new_value = Matrix.new(
-                            value.dtype, nrows=1, ncols=value.size, name=f"{value.name}_as_matrix"
-                        )
-                        new_value[0, :] = value
                         delayed = MatrixExpression(
                             method_name,
                             "GrB_Matrix_assign",
-                            [new_value, rows, rowsize, cols, colsize],
+                            [_VectorAsMatrix(value), rows, rowsize, cols, colsize],
                             expr_repr="[[{2} rows], [{4} cols]] = {0.name}",
                             nrows=self._nrows,
                             ncols=self._ncols,
                             dtype=self.dtype,
+                            at=True,
                         )
                 else:
                     if is_submask:
@@ -845,14 +842,10 @@ class Matrix(BaseType):
                         # Upcast v to a Matrix and use Matrix_assign
                         cols = _CArray([cols.scalar.value])
                         colsize = _CScalar(1)
-                        new_value = Matrix.new(
-                            value.dtype, nrows=value.size, ncols=1, name=f"{value.name}_as_matrix"
-                        )
-                        new_value[:, 0] = value
                         delayed = MatrixExpression(
                             method_name,
                             "GrB_Matrix_assign",
-                            [new_value, rows, rowsize, cols, colsize],
+                            [_VectorAsMatrix(value), rows, rowsize, cols, colsize],
                             expr_repr="[[{2} rows], [{4} cols]] = {0.name}",
                             nrows=self._nrows,
                             ncols=self._ncols,

--- a/grblas/tests/test_prefix_scan.py
+++ b/grblas/tests/test_prefix_scan.py
@@ -4,7 +4,14 @@ import pytest
 import grblas as gb
 from grblas import Matrix, Vector, binary, monoid
 
+try:
+    # gb.io.to_numpy currently requires scipy
+    import scipy.sparse as ss
+except ImportError:  # pragma: no cover
+    ss = None
 
+
+@pytest.mark.skipif("not ss")
 @pytest.mark.parametrize("method", ["scan_rows", "scan_columns"])
 @pytest.mark.parametrize("length", list(range(34)))
 @pytest.mark.parametrize("do_random", [False, True])
@@ -35,6 +42,7 @@ def test_scan_matrix(method, length, do_random):
         raise
 
 
+@pytest.mark.skipif("not ss")
 @pytest.mark.parametrize("length", list(range(34)))
 @pytest.mark.parametrize("do_random", [False, True])
 def test_scan_vector(length, do_random):


### PR DESCRIPTION
If we use a backend other than SuiteSparse:GraphBLAS, I expect `_VectorAsMatrix` would copy the data into a Matrix like we were originally doing.