### PR TITLE
Add xor infix for bools, which performs eadd/union/outer

### DIFF
--- a/grblas/_automethods.py
+++ b/grblas/_automethods.py
@@ -95,6 +95,7 @@ bad_sugar = {
     "__ipow__",
     "__isub__",
     "__itruediv__",
+    "__ixor__",
 }
 # Copy the result of this below
 for name in sorted(common | scalar | vector_matrix | vector | matrix):
@@ -407,3 +408,7 @@ def __isub__(self, other):
 
 def __itruediv__(self, other):
     raise TypeError(f"'__itruediv__' not supported for {type(self).__name__}")
+
+
+def __ixor__(self, other):
+    raise TypeError(f"'__ixor__' not supported for {type(self).__name__}")

--- a/grblas/infix.py
+++ b/grblas/infix.py
@@ -99,6 +99,7 @@ class VectorInfixExpr(InfixExprBase):
     __ipow__ = _automethods.__ipow__
     __isub__ = _automethods.__isub__
     __itruediv__ = _automethods.__itruediv__
+    __ixor__ = _automethods.__ixor__
 
 
 class VectorEwiseAddExpr(VectorInfixExpr):
@@ -207,6 +208,7 @@ class MatrixInfixExpr(InfixExprBase):
     __ipow__ = _automethods.__ipow__
     __isub__ = _automethods.__isub__
     __itruediv__ = _automethods.__itruediv__
+    __ixor__ = _automethods.__ixor__
 
 
 class MatrixEwiseAddExpr(MatrixInfixExpr):

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -1248,6 +1248,7 @@ class MatrixExpression(BaseExpression):
     __ipow__ = _automethods.__ipow__
     __isub__ = _automethods.__isub__
     __itruediv__ = _automethods.__itruediv__
+    __ixor__ = _automethods.__ixor__
 
 
 class TransposedMatrix:
@@ -1350,6 +1351,7 @@ class TransposedMatrix:
     __ipow__ = _automethods.__ipow__
     __isub__ = _automethods.__isub__
     __itruediv__ = _automethods.__itruediv__
+    __ixor__ = _automethods.__ixor__
 
     # Misc.
     isequal = Matrix.isequal

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -2721,6 +2721,8 @@ def test_infix_sugar(A):
         expr %= 1
     with pytest.raises(TypeError):
         expr **= 1
+    with pytest.raises(TypeError):
+        expr ^= 1
 
 
 @pytest.mark.slow

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -2625,6 +2625,14 @@ def test_infix_sugar(A):
         assert unary.lnot(A).isequal(~A)
     with pytest.raises(TypeError):
         assert unary.lnot(A.T).isequal(~A.T)
+    assert binary.lxor(True, B).isequal(True ^ B)
+    assert binary.lxor(B, True).isequal(B ^ True)
+    with pytest.raises(TypeError):
+        A ^ True
+    with pytest.raises(TypeError):
+        A ^ B
+    with pytest.raises(TypeError):
+        6 ^ B
     assert binary.lt(A, 4).isequal(A < 4)
     assert binary.le(A, 4).isequal(A <= 4)
     assert binary.gt(A, 4).isequal(A > 4)
@@ -2685,6 +2693,14 @@ def test_infix_sugar(A):
     B **= 2
     assert type(B) is Matrix
     assert binary.pow(A, 2).isequal(B)
+    B = A.dup(dtype=bool)
+    B ^= True
+    assert type(B) is Matrix
+    assert B.isequal(~A.dup(dtype=bool))
+    B = A.dup(dtype=bool)
+    B ^= B
+    assert type(B) is Matrix
+    assert not B.reduce_scalar(agg.any).new()
 
     expr = binary.plus(A & A)
     assert unary.abs(expr).isequal(abs(expr))

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -830,6 +830,7 @@ class VectorExpression(BaseExpression):
     __ipow__ = _automethods.__ipow__
     __isub__ = _automethods.__isub__
     __itruediv__ = _automethods.__itruediv__
+    __ixor__ = _automethods.__ixor__
 
 
 class _VectorAsMatrix:


### PR DESCRIPTION
Doing `ewise_add` for `xor` is what makes sense.  `xor` is a Monoid with the identity of `False`.