### PR TITLE
Operators may be given as strings in methods: `A.mxm(B, 'min.+[float]')`

### DIFF
--- a/grblas/_ss/prefix_scan.py
+++ b/grblas/_ss/prefix_scan.py
@@ -36,7 +36,7 @@ def prefix_scan(A, monoid, *, name=None, within):
     from .. import Matrix, Vector
     from ..matrix import TransposedMatrix
 
-    monoid = get_typed_op(monoid, A.dtype)
+    monoid = get_typed_op(monoid, A.dtype, kind="binary")
     A._expect_op(monoid, ("BinaryOp", "Monoid"), argname="op", within=within)
     if monoid.opclass == "BinaryOp":
         if monoid.monoid is not None:

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -234,7 +234,7 @@ class BaseType:
             accum = accum_arg
         if accum is not None:
             # Normalize accumulator
-            accum = get_typed_op(accum, self.dtype)
+            accum = get_typed_op(accum, self.dtype, kind="binary")
             if accum.opclass == "Monoid":
                 accum = accum.binaryop
             else:

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -264,7 +264,7 @@ class Matrix(BaseType):
         dup_op_given = dup_op is not None
         if not dup_op_given:
             dup_op = binary.plus
-        dup_op = get_typed_op(dup_op, self.dtype)
+        dup_op = get_typed_op(dup_op, self.dtype, kind="binary")
         if dup_op.opclass == "Monoid":
             dup_op = dup_op.binaryop
         else:
@@ -410,7 +410,7 @@ class Matrix(BaseType):
         other = self._expect_type(
             other, (Matrix, TransposedMatrix), within=method_name, argname="other"
         )
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         if require_monoid:
             if op.opclass != "BinaryOp" or op.monoid is None:
@@ -446,7 +446,7 @@ class Matrix(BaseType):
         other = self._expect_type(
             other, (Matrix, TransposedMatrix), within=method_name, argname="other"
         )
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
         expr = MatrixExpression(
@@ -469,7 +469,7 @@ class Matrix(BaseType):
         """
         method_name = "mxv"
         other = self._expect_type(other, Vector, within=method_name, argname="other")
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
         expr = VectorExpression(
             method_name,
@@ -493,7 +493,7 @@ class Matrix(BaseType):
         other = self._expect_type(
             other, (Matrix, TransposedMatrix), within=method_name, argname="other"
         )
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
         expr = MatrixExpression(
             method_name,
@@ -519,7 +519,7 @@ class Matrix(BaseType):
         other = self._expect_type(
             other, (Matrix, TransposedMatrix), within=method_name, argname="other"
         )
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
         return MatrixExpression(
@@ -545,7 +545,7 @@ class Matrix(BaseType):
             "apply only accepts UnaryOp with no scalars or BinaryOp with `left` or `right` scalar."
         )
         if left is None and right is None:
-            op = get_typed_op(op, self.dtype)
+            op = get_typed_op(op, self.dtype, kind="unary")
             self._expect_op(
                 op,
                 "UnaryOp",
@@ -568,7 +568,7 @@ class Matrix(BaseType):
                         keyword_name="left",
                         extra_message="Literal scalars also accepted.",
                     )
-            op = get_typed_op(op, self.dtype, left.dtype)
+            op = get_typed_op(op, self.dtype, left.dtype, kind="binary")
             if op.opclass == "Monoid":
                 op = op.binaryop
             else:
@@ -594,7 +594,7 @@ class Matrix(BaseType):
                         keyword_name="right",
                         extra_message="Literal scalars also accepted.",
                     )
-            op = get_typed_op(op, self.dtype, right.dtype)
+            op = get_typed_op(op, self.dtype, right.dtype, kind="binary")
             if op.opclass == "Monoid":
                 op = op.binaryop
             else:
@@ -629,7 +629,7 @@ class Matrix(BaseType):
         Default op is monoid.lor for boolean and monoid.plus otherwise
         """
         method_name = "reduce_rowwise"
-        op = get_typed_op(op, self.dtype)
+        op = get_typed_op(op, self.dtype, kind="binary")
         self._expect_op(op, ("BinaryOp", "Monoid", "Aggregator"), within=method_name, argname="op")
         # Using a monoid may be more efficient, so change to one if possible.
         # Also, SuiteSparse doesn't like user-defined binarops here.
@@ -665,7 +665,7 @@ class Matrix(BaseType):
         Default op is monoid.lor for boolean and monoid.plus otherwise
         """
         method_name = "reduce_columnwise"
-        op = get_typed_op(op, self.dtype)
+        op = get_typed_op(op, self.dtype, kind="binary")
         self._expect_op(op, ("BinaryOp", "Monoid", "Aggregator"), within=method_name, argname="op")
         # Using a monoid may be more efficient, so change to one if possible.
         # Also, SuiteSparse doesn't like user-defined binarops here.
@@ -701,7 +701,7 @@ class Matrix(BaseType):
         Default op is monoid.lor for boolean and monoid.plus otherwise
         """
         method_name = "reduce_scalar"
-        op = get_typed_op(op, self.dtype)
+        op = get_typed_op(op, self.dtype, kind="binary")
         if op.opclass == "BinaryOp" and op.monoid is not None:
             op = op.monoid
         else:

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -144,7 +144,7 @@ class Scalar(BaseType):
             return self.is_empty is other.is_empty
         # We can't yet call a UDF on a scalar as part of the spec, so let's do it ourselves
         isclose_func = isclose(rel_tol, abs_tol)
-        isclose_func = get_typed_op(isclose_func, self.dtype, other.dtype)
+        isclose_func = get_typed_op(isclose_func, self.dtype, other.dtype, kind="binary")
         return isclose_func.numba_func(self.value, other.value)
 
     def clear(self):

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -896,4 +896,6 @@ def test_from_string():
     with pytest.raises(ValueError, match="Unknown binary string"):
         assert binary.from_string("badname")
     with pytest.raises(ValueError, match="Bad semiring string"):
+        assert semiring.from_string("badname")
+    with pytest.raises(ValueError, match="Bad semiring string"):
         semiring.from_string("min.plus.times")

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -98,6 +98,13 @@ def test_get_typed_op():
         operator.get_typed_op(binary.bor, dtypes.FP64)
     with pytest.raises(TypeError, match="Unable to get typed operator"):
         operator.get_typed_op(object(), dtypes.INT64)
+    assert operator.get_typed_op("<", dtypes.INT64, kind="binary") is binary.lt["INT64"]
+    assert operator.get_typed_op("-", dtypes.INT64, kind="unary") is unary.ainv["INT64"]
+    assert operator.get_typed_op("+", dtypes.FP64, kind="monoid") is monoid.plus["FP64"]
+    assert operator.get_typed_op("+[int64]", dtypes.FP64, kind="monoid") is monoid.plus["INT64"]
+    assert operator.get_typed_op("+.*", dtypes.FP64, kind="semiring") is semiring.plus_times["FP64"]
+    with pytest.raises(ValueError, match="Unable to get op from string"):
+        operator.get_typed_op("+", dtypes.FP64)
 
 
 def test_unaryop_udf():
@@ -863,3 +870,30 @@ def test_commutes():
         if not hasattr(val, "commutes_to"):
             continue
         assert val.commutes_to is None or isinstance(val.commutes_to, type(val))
+
+
+def test_from_string():
+    assert unary.from_string("-") is unary.ainv
+    assert unary.from_string("abs[float]") is unary.abs[float]
+    assert binary.from_string("+") is binary.plus
+    assert binary.from_string("-[int]") is binary.minus[int]
+    assert binary.from_string("true_divide") is binary.numpy.true_divide
+    assert monoid.from_string("*[FP64]") is monoid.times["FP64"]
+    assert semiring.from_string("min.plus") is semiring.min_plus
+    assert semiring.from_string("min.+") is semiring.min_plus
+    assert semiring.from_string("min_plus") is semiring.min_plus
+
+    with pytest.raises(ValueError, match="does not end with"):
+        assert binary.from_string("plus[int")
+    with pytest.raises(ValueError, match="too many"):
+        assert binary.from_string("plus[int][float]")
+    with pytest.raises(ValueError, match="not matched by"):
+        assert binary.from_string("plus][int]")
+    with pytest.raises(ValueError, match="does not end with"):
+        assert binary.from_string("plus[int]extra")
+    with pytest.raises(ValueError, match="Unknown binary string"):
+        assert binary.from_string("")
+    with pytest.raises(ValueError, match="Unknown binary string"):
+        assert binary.from_string("badname")
+    with pytest.raises(ValueError, match="Bad semiring string"):
+        semiring.from_string("min.plus.times")

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -231,7 +231,7 @@ class Vector(BaseType):
         dup_op_given = dup_op is not None
         if not dup_op_given:
             dup_op = binary.plus
-        dup_op = get_typed_op(dup_op, self.dtype)
+        dup_op = get_typed_op(dup_op, self.dtype, kind="binary")
         if dup_op.opclass == "Monoid":
             dup_op = dup_op.binaryop
         else:
@@ -350,7 +350,7 @@ class Vector(BaseType):
         """
         method_name = "ewise_add"
         other = self._expect_type(other, Vector, within=method_name, argname="other")
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         if require_monoid:
             if op.opclass != "BinaryOp" or op.monoid is None:
@@ -382,7 +382,7 @@ class Vector(BaseType):
         """
         method_name = "ewise_mult"
         other = self._expect_type(other, Vector, within=method_name, argname="other")
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
         expr = VectorExpression(
@@ -407,7 +407,7 @@ class Vector(BaseType):
         other = self._expect_type(
             other, (Matrix, TransposedMatrix), within=method_name, argname="other"
         )
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
         expr = VectorExpression(
             method_name,
@@ -433,7 +433,7 @@ class Vector(BaseType):
             "apply only accepts UnaryOp with no scalars or BinaryOp with `left` or `right` scalar."
         )
         if left is None and right is None:
-            op = get_typed_op(op, self.dtype)
+            op = get_typed_op(op, self.dtype, kind="unary")
             self._expect_op(
                 op,
                 "UnaryOp",
@@ -456,7 +456,7 @@ class Vector(BaseType):
                         keyword_name="left",
                         extra_message="Literal scalars also accepted.",
                     )
-            op = get_typed_op(op, self.dtype, left.dtype)
+            op = get_typed_op(op, self.dtype, left.dtype, kind="binary")
             if op.opclass == "Monoid":
                 op = op.binaryop
             else:
@@ -482,7 +482,7 @@ class Vector(BaseType):
                         keyword_name="right",
                         extra_message="Literal scalars also accepted.",
                     )
-            op = get_typed_op(op, self.dtype, right.dtype)
+            op = get_typed_op(op, self.dtype, right.dtype, kind="binary")
             if op.opclass == "Monoid":
                 op = op.binaryop
             else:
@@ -514,7 +514,7 @@ class Vector(BaseType):
         Default op is monoid.lor for boolean and monoid.plus otherwise
         """
         method_name = "reduce"
-        op = get_typed_op(op, self.dtype)
+        op = get_typed_op(op, self.dtype, kind="binary")
         if op.opclass == "BinaryOp" and op.monoid is not None:
             op = op.monoid
         else:
@@ -537,7 +537,7 @@ class Vector(BaseType):
         """
         method_name = "inner"
         other = self._expect_type(other, Vector, within=method_name, argname="other")
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
         expr = ScalarExpression(
             method_name,
@@ -561,7 +561,7 @@ class Vector(BaseType):
 
         method_name = "outer"
         other = self._expect_type(other, Vector, within=method_name, argname="other")
-        op = get_typed_op(op, self.dtype, other.dtype)
+        op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
         if op.opclass == "Monoid":
             op = op.binaryop


### PR DESCRIPTION
@jim22k this was pretty easy to add, and may actually be kinda nice!