### PR TITLE
Make `dtype=` an optional positional argument.

### DIFF
--- a/grblas/_agg.py
+++ b/grblas/_agg.py
@@ -126,7 +126,7 @@ class TypedAggregator:
             mask = updater.kwargs.get("mask")
             for cur_agg in agg._composite:
                 cur_agg = cur_agg[self.type]  # Hopefully works well enough
-                arg = expr.construct_output(dtype=cur_agg.return_type)
+                arg = expr.construct_output(cur_agg.return_type)
                 results.append(cur_agg._new(arg(mask=mask), expr, in_composite=True))
             final_expr = agg._finalize(*results)
             if expr.cfunc_name == "GrB_Matrix_reduce_Aggregator":
@@ -161,7 +161,7 @@ class TypedAggregator:
             A = expr.args[0]
             orig_updater = updater
             if agg._finalize is not None:
-                step1 = expr.construct_output(dtype=semiring.return_type)
+                step1 = expr.construct_output(semiring.return_type)
                 updater = step1(mask=updater.kwargs.get("mask"))
             if expr.method_name == "reduce_columnwise":
                 A = A.T
@@ -191,7 +191,7 @@ class TypedAggregator:
                 if step1.dtype == finalize.return_type:
                     step1 << finalize(step1)
                 else:
-                    step1 = finalize(step1).new(dtype=finalize.return_type)
+                    step1 = finalize(step1).new(finalize.return_type)
             if in_composite:
                 return step1
             expr = step1.reduce(_any)
@@ -221,7 +221,7 @@ class TypedAggregator:
                 if step2.dtype == finalize.return_type:
                     step2 << finalize(step2)
                 else:
-                    step2 = finalize(step2).new(dtype=finalize.return_type)
+                    step2 = finalize(step2).new(finalize.return_type)
             if in_composite:
                 return step2
             expr = step2.reduce(_any)

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -107,7 +107,7 @@ def _head_hypercsr_rows(indptr, rows, n):  # pragma: no cover
     return rv
 
 
-def head(matrix, n=10, *, sort=False, dtype=None):
+def head(matrix, n=10, dtype=None, *, sort=False):
     """Like ``matrix.to_values()``, but only returns the first n elements.
 
     If sort is True, then the results will be sorted as appropriate for the internal format,
@@ -384,7 +384,7 @@ class ss:
         Vector.ss.diag
         """
         vector = self._parent._expect_type(vector, gb.Vector, within="ss.diag", argname="vector")
-        call("GxB_Matrix_diag", [self._parent, vector, _CScalar(k, dtype=INT64), None])
+        call("GxB_Matrix_diag", [self._parent, vector, _CScalar(k, INT64), None])
 
     def split(self, chunks, *, name=None):
         """
@@ -3400,8 +3400,8 @@ class ss:
             raise ValueError(f"Invalid format: {format}")
 
     @wrapdoc(head)
-    def head(self, n=10, *, sort=False, dtype=None):
-        return head(self._parent, n, sort=sort, dtype=dtype)
+    def head(self, n=10, dtype=None, *, sort=False):
+        return head(self._parent, n, dtype, sort=sort)
 
     def scan_columnwise(self, op=monoid.plus, *, name=None):
         """Perform a prefix scan across columns with the given monoid.

--- a/grblas/_ss/vector.py
+++ b/grblas/_ss/vector.py
@@ -43,7 +43,7 @@ def _head_indices_vector_bitmap(bitmap, values, size, dtype, n, is_iso):  # prag
     return indices, vals
 
 
-def head(vector, n=10, *, sort=False, dtype=None):
+def head(vector, n=10, dtype=None, *, sort=False):
     """Like ``vector.to_values()``, but only returns the first n elements.
 
     If sort is True, then the results will be sorted by index, otherwise the order of the
@@ -146,7 +146,7 @@ class ss:
             # Transpose descriptor doesn't do anything, so use the parent
             k = -k
             matrix = matrix._matrix
-        call("GxB_Vector_diag", [self._parent, matrix, _CScalar(k, dtype=INT64), None])
+        call("GxB_Vector_diag", [self._parent, matrix, _CScalar(k, INT64), None])
 
     def build_scalar(self, indices, value):
         """
@@ -1033,8 +1033,8 @@ class ss:
         return vector
 
     @wrapdoc(head)
-    def head(self, n=10, *, sort=False, dtype=None):
-        return head(self._parent, n, sort=sort, dtype=dtype)
+    def head(self, n=10, dtype=None, *, sort=False):
+        return head(self._parent, n, dtype, sort=sort)
 
     def scan(self, op=monoid.plus, *, name=None):
         """Perform a prefix scan with the given monoid.

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -327,7 +327,7 @@ class BaseType:
                             "Scalar accumulation with extract element"
                             "--such as `s(accum=accum) << v[0]`--is not supported"
                         )
-                    self.value = delayed.new(dtype=self.dtype, name="s_extract").value
+                    self.value = delayed.new(self.dtype, name="s_extract").value
                     return
 
                 # Extract (C << A[rows, cols])
@@ -524,7 +524,7 @@ class BaseExpression:
             self.dtype = dtype
         self._value = None
 
-    def new(self, *, dtype=None, mask=None, name=None):
+    def new(self, dtype=None, *, mask=None, name=None):
         if (
             mask is None
             and self._value is not None
@@ -535,7 +535,7 @@ class BaseExpression:
                 rv.name = name
             self._value = None
             return rv
-        output = self.construct_output(dtype=dtype, name=name)
+        output = self.construct_output(dtype, name=name)
         if self.op is not None and self.op.opclass == "Aggregator":
             updater = output(mask=mask)
             self.op._new(updater, self)

--- a/grblas/expr.py
+++ b/grblas/expr.py
@@ -179,7 +179,7 @@ class AmbiguousAssignOrExtract:
         scalar = self.parent._extract_element(self.resolved_indexes, name="s_extract")
         return scalar.value
 
-    def new(self, *, dtype=None, mask=None, input_mask=None, name=None):
+    def new(self, dtype=None, *, mask=None, input_mask=None, name=None):
         """
         Force extraction of the indexes into a new object
         dtype and mask are the only controllable parameters.
@@ -187,7 +187,7 @@ class AmbiguousAssignOrExtract:
         if self.resolved_indexes.is_single_element:
             if mask is not None or input_mask is not None:
                 raise TypeError("mask is not allowed for single element extraction")
-            return self.parent._extract_element(self.resolved_indexes, dtype=dtype, name=name)
+            return self.parent._extract_element(self.resolved_indexes, dtype, name=name)
         else:
             if input_mask is not None:
                 if mask is not None:
@@ -197,7 +197,7 @@ class AmbiguousAssignOrExtract:
                 _check_mask(input_mask, output=self.parent)
                 mask = self._input_mask_to_mask(input_mask)
             delayed_extractor = self.parent._prep_for_extract(self.resolved_indexes)
-            return delayed_extractor.new(dtype=dtype, mask=mask, name=name)
+            return delayed_extractor.new(dtype, mask=mask, name=name)
 
     def __eq__(self, other):
         if not self.resolved_indexes.is_single_element:
@@ -342,7 +342,7 @@ class InfixExprBase:
         self.right = right
         self._value = None
 
-    def new(self, *, dtype=None, mask=None, name=None):
+    def new(self, dtype=None, *, mask=None, name=None):
         if (
             mask is None
             and self._value is not None
@@ -354,7 +354,7 @@ class InfixExprBase:
             self._value = None
             return rv
         expr = self._to_expr()
-        return expr.new(dtype=dtype, mask=mask, name=name)
+        return expr.new(dtype, mask=mask, name=name)
 
     dup = new
 

--- a/grblas/infix.py
+++ b/grblas/infix.py
@@ -255,10 +255,10 @@ class ScalarMatMulExpr(InfixExprBase):
     shape = ()
     _is_scalar = True
 
-    def new(self, *, dtype=None, name=None):
+    def new(self, dtype=None, *, name=None):
         # Rely on the default operator for the method
         expr = getattr(self.left, self.method_name)(self.right)
-        return expr.new(dtype=dtype, name=name)
+        return expr.new(dtype, name=name)
 
     dup = new
 

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -157,7 +157,7 @@ class Matrix(BaseType):
             return False
 
         matches = self.ewise_mult(other, binary.isclose(rel_tol, abs_tol)).new(
-            dtype=bool, name="M_isclose"
+            bool, name="M_isclose"
         )
         # ewise_mult performs intersection, so nvals will indicate mismatched empty values
         if matches._nvals != self._nvals:
@@ -212,7 +212,7 @@ class Matrix(BaseType):
         self._nrows = nrows.scalar.value
         self._ncols = ncols.scalar.value
 
-    def to_values(self, *, dtype=None):
+    def to_values(self, dtype=None):
         """
         GrB_Matrix_extractTuples
         Extract the rows, columns and values as a 3-tuple of numpy arrays
@@ -272,7 +272,7 @@ class Matrix(BaseType):
 
         rows = _CArray(rows)
         columns = _CArray(columns)
-        values = _CArray(values, dtype=self.dtype)
+        values = _CArray(values, self.dtype)
         call(
             f"GrB_Matrix_build_{self.dtype.name}",
             [self, rows, columns, values, _CScalar(n), dup_op],
@@ -281,7 +281,7 @@ class Matrix(BaseType):
         if not dup_op_given and self._nvals < n:
             raise ValueError("Duplicate indices found, must provide `dup_op` BinaryOp")
 
-    def dup(self, *, dtype=None, mask=None, name=None):
+    def dup(self, dtype=None, *, mask=None, name=None):
         """
         GrB_Matrix_dup
         Create a new Matrix by duplicating this one
@@ -333,11 +333,11 @@ class Matrix(BaseType):
         rows,
         columns,
         values,
+        dtype=None,
         *,
         nrows=None,
         ncols=None,
         dup_op=None,
-        dtype=None,
         name=None,
     ):
         """Create a new Matrix from the given lists of row indices, column
@@ -533,7 +533,7 @@ class Matrix(BaseType):
             bt=other._is_transposed,
         )
 
-    def apply(self, op, *, left=None, right=None):
+    def apply(self, op, right=None, *, left=None):
         """
         GrB_Matrix_apply
         Apply UnaryOp to each element of the calling Matrix
@@ -1271,7 +1271,7 @@ class TransposedMatrix:
 
         return format_matrix_html(self)
 
-    def new(self, *, dtype=None, mask=None, name=None):
+    def new(self, dtype=None, *, mask=None, name=None):
         if dtype is None:
             dtype = self.dtype
         output = Matrix.new(dtype, self._nrows, self._ncols, name=name)
@@ -1296,8 +1296,8 @@ class TransposedMatrix:
         return self._matrix.dtype
 
     @wrapdoc(Matrix.to_values)
-    def to_values(self, *, dtype=None):
-        rows, cols, vals = self._matrix.to_values(dtype=dtype)
+    def to_values(self, dtype=None):
+        rows, cols, vals = self._matrix.to_values(dtype)
         return cols, rows, vals
 
     @property

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -161,9 +161,7 @@ class TypedBuiltinMonoid(TypedOpBase):
             from .vector import Vector
 
             with skip_record:
-                self._identity = (
-                    Vector.new(size=1, dtype=self.type, name="").reduce(self).new().value
-                )
+                self._identity = Vector.new(self.type, size=1, name="").reduce(self).new().value
         return self._identity
 
     @property

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -180,7 +180,7 @@ class Scalar(BaseType):
 
     _nvals = nvals
 
-    def dup(self, *, dtype=None, name=None):
+    def dup(self, dtype=None, *, name=None):
         """Create a new Scalar by duplicating this one"""
         if dtype is None:
             new_scalar = Scalar.new(self.dtype, name=name)
@@ -207,9 +207,9 @@ class Scalar(BaseType):
     def from_value(cls, value, dtype=None, *, name=None):
         """Create a new Scalar from a Python value"""
         if type(value) is Scalar:
-            return value.dup(dtype=dtype, name=name)
+            return value.dup(dtype, name=name)
         elif output_type(value) is Scalar:
-            return value.new(dtype=dtype, name=name)
+            return value.new(dtype, name=name)
         elif dtype is None:
             try:
                 dtype = lookup_dtype(type(value))
@@ -226,7 +226,7 @@ class Scalar(BaseType):
 
     @staticmethod
     def _deserialize(value, dtype, name):
-        return Scalar.from_value(value, dtype=dtype, name=name)
+        return Scalar.from_value(value, dtype, name=name)
 
     def to_pygraphblas(self):  # pragma: no cover
         """Convert to a new `pygraphblas.Scalar`
@@ -270,8 +270,8 @@ class ScalarExpression(BaseExpression):
             dtype = self.dtype
         return Scalar.new(dtype, name=name)
 
-    def new(self, *, dtype=None, name=None):
-        return super().new(dtype=dtype, name=name)
+    def new(self, dtype=None, *, name=None):
+        return super().new(dtype, name=name)
 
     dup = new
 
@@ -330,7 +330,7 @@ class _CScalar:
 
     def __init__(self, scalar, dtype=_INDEX):
         if type(scalar) is not Scalar:
-            scalar = Scalar.from_value(scalar, name="", dtype=dtype)
+            scalar = Scalar.from_value(scalar, dtype, name="")
         self.scalar = scalar
         self.dtype = scalar.dtype
 

--- a/grblas/ss/_core.py
+++ b/grblas/ss/_core.py
@@ -14,7 +14,7 @@ _grblas_ss.__name__ = "grblas.ss"
 _grblas_ss = _grblas_ss()
 
 
-def diag(x, k=0, *, dtype=None, name=None):
+def diag(x, k=0, dtype=None, *, name=None):
     """
     GxB_Matrix_diag, GxB_Vector_diag
 
@@ -39,7 +39,7 @@ def diag(x, k=0, *, dtype=None, name=None):
     """
     x = _expect_type(_grblas_ss, x, (Matrix, TransposedMatrix, Vector), within="diag", argname="x")
     if type(k) is not Scalar:
-        k = Scalar.from_value(k, dtype=INT64, name="")
+        k = Scalar.from_value(k, INT64, name="")
     if dtype is None:
         dtype = x.dtype
     typ = type(x)
@@ -59,7 +59,7 @@ def diag(x, k=0, *, dtype=None, name=None):
     return rv
 
 
-def concat(tiles, *, dtype=None, name=None):
+def concat(tiles, dtype=None, *, name=None):
     """
     GxB_Matrix_concat
 

--- a/grblas/utils.py
+++ b/grblas/utils.py
@@ -123,7 +123,7 @@ class class_property:
 class _CArray:
     __slots__ = "array", "_carg", "dtype", "_name"
 
-    def __init__(self, array=None, *, size=None, dtype=_INDEX, name=None):
+    def __init__(self, array=None, dtype=_INDEX, *, size=None, name=None):
         if size is not None:
             self.array = np.empty(size, dtype=dtype.np_type)
         else:

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -146,7 +146,7 @@ class Vector(BaseType):
             return False
 
         matches = self.ewise_mult(other, binary.isclose(rel_tol, abs_tol)).new(
-            dtype=bool, name="M_isclose"
+            bool, name="M_isclose"
         )
         # ewise_mult performs intersection, so nvals will indicate mismatched empty values
         if matches._nvals != self._nvals:
@@ -188,7 +188,7 @@ class Vector(BaseType):
         call("GrB_Vector_resize", [self, size])
         self._size = size.scalar.value
 
-    def to_values(self, *, dtype=None):
+    def to_values(self, dtype=None):
         """
         GrB_Vector_extractTuples
         Extract the indices and values as a 2-tuple of numpy arrays
@@ -238,14 +238,14 @@ class Vector(BaseType):
             self._expect_op(dup_op, "BinaryOp", within="build", argname="dup_op")
 
         indices = _CArray(indices)
-        values = _CArray(values, dtype=self.dtype)
+        values = _CArray(values, self.dtype)
         call(f"GrB_Vector_build_{self.dtype.name}", [self, indices, values, _CScalar(n), dup_op])
 
         # Check for duplicates when dup_op was not provided
         if not dup_op_given and self._nvals < n:
             raise ValueError("Duplicate indices found, must provide `dup_op` BinaryOp")
 
-    def dup(self, *, dtype=None, mask=None, name=None):
+    def dup(self, dtype=None, *, mask=None, name=None):
         """
         GrB_Vector_dup
         Create a new Vector by duplicating this one
@@ -288,7 +288,7 @@ class Vector(BaseType):
         return rv
 
     @classmethod
-    def from_values(cls, indices, values, *, size=None, dup_op=None, dtype=None, name=None):
+    def from_values(cls, indices, values, dtype=None, *, size=None, dup_op=None, name=None):
         """Create a new Vector from the given lists of indices and values.  If
         size is not provided, it is computed from the max index found.
 
@@ -421,7 +421,7 @@ class Vector(BaseType):
             expr.new(name="")  # incompatible shape; raise now
         return expr
 
-    def apply(self, op, *, left=None, right=None):
+    def apply(self, op, right=None, *, left=None):
         """
         GrB_Vector_apply
         Apply UnaryOp to each element of the calling Vector


### PR DESCRIPTION
I've been annoyed that `dtype=` was keyword-only.