### PR TITLE
Better error message for e.g. `A + B`

### DIFF
--- a/grblas/infix.py
+++ b/grblas/infix.py
@@ -389,4 +389,5 @@ def _matmul_infix_expr(left, right, *, within):
     return ScalarMatMulExpr(left, right)
 
 
+# Import _infixmethods, which has side effects
 from . import _infixmethods  # noqa isort:skip

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -1371,3 +1371,6 @@ class TransposedMatrix:
 utils._output_types[Matrix] = Matrix
 utils._output_types[MatrixExpression] = Matrix
 utils._output_types[TransposedMatrix] = TransposedMatrix
+
+# Import infix to import _infixmethods, which has side effects
+from . import infix  # noqa isort:skip

--- a/grblas/tests/test_infix.py
+++ b/grblas/tests/test_infix.py
@@ -267,3 +267,8 @@ def test_apply_binary_bad(s1, v1):
         op.plus(v1, v1)
     with raises(TypeError, match="may only be used when performing an ewise_add"):
         op.plus(v1, 1, require_monoid=False)
+
+
+def test_infix_nonscalars(v1, v2):
+    with raises(TypeError, match="refuse to guess"):
+        v1 + v2

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -860,3 +860,6 @@ class _VectorAsMatrix:
 
 utils._output_types[Vector] = Vector
 utils._output_types[VectorExpression] = Vector
+
+# Import matrix to import infix to import _infixmethods, which has side effects
+from . import matrix  # noqa isort:skip


### PR DESCRIPTION
Example error message:
```
TypeError: Infix operator __add__ between Vector and Vector is not supported.  This infix operation is only allowed if one of the arguments is a scalar.  We refuse to guess whether you intend to do ewise_mult or ewise_add.

You must indicate ewise_mult (intersection) or ewise_add (union) explicitly.

For ewise_mult:
    >>> op.plus(x & y)
or
    >>> x.ewise_mult(y, op.plus)

For ewise_add:
    >>> op.plus(x | y)
or
    >>> x.ewise_add(y, op.plus)
```