### PR TITLE
Include operator in `expect_type` error message.

### DIFF
--- a/grblas/base.py
+++ b/grblas/base.py
@@ -55,7 +55,7 @@ def call(cfunc_name, args):
 
 
 def _expect_type_message(
-    self, x, types, *, within, argname=None, keyword_name=None, extra_message=""
+    self, x, types, *, within, argname=None, keyword_name=None, op=None, extra_message=""
 ):
     if type(types) is tuple:
         if type(x) in types:
@@ -90,8 +90,13 @@ def _expect_type_message(
         expected = types.__name__
     if extra_message:
         extra_message = f"\n{extra_message}"
+    op, opclass = find_opclass(op)
+    if opclass == UNKNOWN_OPCLASS:
+        argstr = "..."
+    else:
+        argstr = f"op={op}"
     return x, (
-        f"Bad type {argmsg}in {type(self).__name__}.{within}(...).\n"
+        f"Bad type {argmsg}in {type(self).__name__}.{within}({argstr}).\n"
         f"    - Expected type: {expected}.\n"
         f"    - Got: {type(x)}."
         f"{extra_message}"

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -406,7 +406,11 @@ class Matrix(BaseType):
         """
         method_name = "ewise_add"
         other = self._expect_type(
-            other, (Matrix, TransposedMatrix), within=method_name, argname="other"
+            other,
+            (Matrix, TransposedMatrix),
+            within=method_name,
+            argname="other",
+            op=op,
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
@@ -442,7 +446,7 @@ class Matrix(BaseType):
         """
         method_name = "ewise_mult"
         other = self._expect_type(
-            other, (Matrix, TransposedMatrix), within=method_name, argname="other"
+            other, (Matrix, TransposedMatrix), within=method_name, argname="other", op=op
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
@@ -466,7 +470,7 @@ class Matrix(BaseType):
         Default op is semiring.plus_times
         """
         method_name = "mxv"
-        other = self._expect_type(other, Vector, within=method_name, argname="other")
+        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
         op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
         expr = VectorExpression(
@@ -489,7 +493,7 @@ class Matrix(BaseType):
         """
         method_name = "mxm"
         other = self._expect_type(
-            other, (Matrix, TransposedMatrix), within=method_name, argname="other"
+            other, (Matrix, TransposedMatrix), within=method_name, argname="other", op=op
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
@@ -515,7 +519,7 @@ class Matrix(BaseType):
         """
         method_name = "kronecker"
         other = self._expect_type(
-            other, (Matrix, TransposedMatrix), within=method_name, argname="other"
+            other, (Matrix, TransposedMatrix), within=method_name, argname="other", op=op
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
@@ -565,6 +569,7 @@ class Matrix(BaseType):
                         within=method_name,
                         keyword_name="left",
                         extra_message="Literal scalars also accepted.",
+                        op=op,
                     )
             op = get_typed_op(op, left.dtype, self.dtype, is_left_scalar=True, kind="binary")
             if op.opclass == "Monoid":
@@ -591,6 +596,7 @@ class Matrix(BaseType):
                         within=method_name,
                         keyword_name="right",
                         extra_message="Literal scalars also accepted.",
+                        op=op,
                     )
             op = get_typed_op(op, self.dtype, right.dtype, is_right_scalar=True, kind="binary")
             if op.opclass == "Monoid":

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -348,7 +348,7 @@ class Vector(BaseType):
         For these reasons, users are required to be explicit when choosing this surprising behavior.
         """
         method_name = "ewise_add"
-        other = self._expect_type(other, Vector, within=method_name, argname="other")
+        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         if require_monoid:
@@ -380,7 +380,7 @@ class Vector(BaseType):
         Default op is binary.times
         """
         method_name = "ewise_mult"
-        other = self._expect_type(other, Vector, within=method_name, argname="other")
+        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
@@ -404,7 +404,7 @@ class Vector(BaseType):
 
         method_name = "vxm"
         other = self._expect_type(
-            other, (Matrix, TransposedMatrix), within=method_name, argname="other"
+            other, (Matrix, TransposedMatrix), within=method_name, argname="other", op=op
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
@@ -454,6 +454,7 @@ class Vector(BaseType):
                         within=method_name,
                         keyword_name="left",
                         extra_message="Literal scalars also accepted.",
+                        op=op,
                     )
             op = get_typed_op(op, left.dtype, self.dtype, is_left_scalar=True, kind="binary")
             if op.opclass == "Monoid":
@@ -480,6 +481,7 @@ class Vector(BaseType):
                         within=method_name,
                         keyword_name="right",
                         extra_message="Literal scalars also accepted.",
+                        op=op,
                     )
             op = get_typed_op(op, self.dtype, right.dtype, is_right_scalar=True, kind="binary")
             if op.opclass == "Monoid":
@@ -535,7 +537,7 @@ class Vector(BaseType):
         *This is not a standard GraphBLAS function*
         """
         method_name = "inner"
-        other = self._expect_type(other, Vector, within=method_name, argname="other")
+        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
         op = get_typed_op(op, self.dtype, other.dtype, kind="semiring")
         self._expect_op(op, "Semiring", within=method_name, argname="op")
         expr = ScalarExpression(
@@ -559,7 +561,7 @@ class Vector(BaseType):
         from .matrix import MatrixExpression
 
         method_name = "outer"
-        other = self._expect_type(other, Vector, within=method_name, argname="other")
+        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
         if op.opclass == "Monoid":


### PR DESCRIPTION
This can help identify which call in a large expression is causing the error.