### PR TITLE
Add format to repr and a couple other minor repr changes.

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -51,12 +51,12 @@ jobs:
           conda activate grblas
           conda install -c conda-forge pandas numba scipy networkx cffi
           if [[ ${{ matrix.sourcetype }} == "wheel" ]]; then
-              pip install suitesparse-graphblas==5.1.10.0
+              pip install suitesparse-graphblas
           else
               conda install -c conda-forge graphblas
           fi
           if [[ ${{ matrix.sourcetype }} == "source" ]]; then
-              pip install --no-binary=all suitesparse-graphblas==5.1.10.0
+              pip install --no-binary=all suitesparse-graphblas
           elif [[ ${{ matrix.sourcetype }} == "upstream" ]]; then
               # I can't get pip install from git to work, so git clone instead.
               # pip install git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -51,12 +51,12 @@ jobs:
           conda activate grblas
           conda install -c conda-forge pandas numba scipy networkx cffi
           if [[ ${{ matrix.sourcetype }} == "wheel" ]]; then
-              pip install suitesparse-graphblas
+              pip install suitesparse-graphblas==5.1.10.0
           else
               conda install -c conda-forge graphblas
           fi
           if [[ ${{ matrix.sourcetype }} == "source" ]]; then
-              pip install --no-binary=all suitesparse-graphblas
+              pip install --no-binary=all suitesparse-graphblas==5.1.10.0
           elif [[ ${{ matrix.sourcetype }} == "upstream" ]]; then
               # I can't get pip install from git to work, so git clone instead.
               # pip install git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas

--- a/grblas/formatting.py
+++ b/grblas/formatting.py
@@ -302,6 +302,16 @@ def _get_vector_dataframe(vector, max_rows, min_rows, max_columns, *, mask=None)
     return df.where(pd.notnull(df), "")
 
 
+def get_format(x, is_transposed=False):
+    # SS, SuiteSparse-specific: format (ends with "r" or "c"), and is_iso
+    fmt = x.ss.format
+    if is_transposed:
+        fmt = fmt[:-1] + ("c" if fmt[-1] == "r" else "r")
+    if x.ss.is_iso:
+        return f"{fmt} (iso)"
+    return fmt
+
+
 def matrix_info(matrix, *, mask=None, for_html=True):
     if mask is not None:
         if for_html:
@@ -312,13 +322,10 @@ def matrix_info(matrix, *, mask=None, for_html=True):
         name = f"grblas.{type(matrix).__name__}"
     keys = ["nvals", "nrows", "ncols", "dtype", "format"]
     vals = [matrix._nvals, matrix._nrows, matrix._ncols, matrix.dtype.name]
-    # SS, SuiteSparse-specific: format (ends with "r" or "c")
     if type(matrix) is Matrix:
-        vals.append(matrix.ss.format)
+        vals.append(get_format(matrix))
     else:  # TransposedMatrix
-        fmt = matrix._matrix.ss.format
-        fmt = fmt[:-1] + ("c" if fmt[-1] == "r" else "r")
-        vals.append(fmt)
+        vals.append(get_format(matrix._matrix, is_transposed=True))
     return name, keys, vals
 
 
@@ -332,7 +339,7 @@ def vector_info(vector, *, mask=None, for_html=True):
         name = f"grblas.{type(vector).__name__}"
     # SS, SuiteSparse-specific: format
     keys = ["nvals", "size", "dtype", "format"]
-    vals = [vector._nvals, vector._size, vector.dtype.name, vector.ss.format]
+    vals = [vector._nvals, vector._size, vector.dtype.name, get_format(vector)]
     return name, keys, vals
 
 

--- a/grblas/formatting.py
+++ b/grblas/formatting.py
@@ -472,6 +472,15 @@ def format_matrix_expression_html(expr):
     return _format_expression(expr, header)
 
 
+def get_result_string(expr):
+    if config.get("autocompute"):
+        arg_string = get_expr_result(expr)
+        arg_string += "\n\n"
+    else:
+        arg_string = ""
+    return arg_string
+
+
 def format_matrix_expression(expr):
     expr_repr = expr._format_expr()
     name = f"grblas.{type(expr).__name__}"
@@ -482,11 +491,7 @@ def format_matrix_expression(expr):
         name=name,
         quote=False,
     )
-    if config.get("autocompute"):
-        arg_string = get_expr_result(expr)
-        arg_string += "\n\n"
-    else:
-        arg_string = ""
+    arg_string = get_result_string(expr)
     return (
         f"{header}\n\n"
         f"{arg_string}"
@@ -506,11 +511,7 @@ def format_vector_expression(expr):
     header = create_header(
         expr_repr, ["size", "dtype"], [expr._size, expr.dtype], name=name, quote=False
     )
-    if config.get("autocompute"):
-        arg_string = get_expr_result(expr)
-        arg_string += "\n\n"
-    else:
-        arg_string = ""
+    arg_string = get_result_string(expr)
     return (
         f"{header}\n\n"
         f"{arg_string}"
@@ -528,11 +529,7 @@ def format_scalar_expression(expr):
     expr_repr = expr._format_expr()
     name = f"grblas.{type(expr).__name__}"
     header = create_header(expr_repr, ["dtype"], [expr.dtype], name=name, quote=False)
-    if config.get("autocompute"):
-        arg_string = get_expr_result(expr)
-        arg_string += "\n\n"
-    else:
-        arg_string = ""
+    arg_string = get_result_string(expr)
     return (
         f"{header}\n\n"
         f"{arg_string}"
@@ -639,11 +636,7 @@ def format_scalar_infix_expression(expr):
         name=name,
         quote=False,
     )
-    if config.get("autocompute"):
-        arg_string = get_expr_result(expr)
-        arg_string += "\n\n"
-    else:
-        arg_string = ""
+    arg_string = get_result_string(expr)
     return (
         f"{header}\n\n"
         f"{arg_string}"
@@ -662,6 +655,18 @@ def format_scalar_infix_expression_html(expr):
     return _format_infix_expression(expr, header, expr_html)
 
 
+def get_infix_result_string(expr):
+    if (
+        expr.method_name not in {"ewise_add", "ewise_mult"}
+        or expr.left.dtype == BOOL
+        and expr.right.dtype == BOOL
+    ):
+        arg_string = get_result_string(expr)
+    else:
+        arg_string = ""
+    return arg_string
+
+
 def format_vector_infix_expression(expr):
     expr_repr = expr._format_expr()
     name = f"grblas.{type(expr).__name__}"
@@ -672,15 +677,7 @@ def format_vector_infix_expression(expr):
         name=name,
         quote=False,
     )
-    if config.get("autocompute") and (
-        expr.method_name not in {"ewise_add", "ewise_mult"}
-        or expr.left.dtype == BOOL
-        and expr.right.dtype == BOOL
-    ):
-        arg_string = get_expr_result(expr)
-        arg_string += "\n\n"
-    else:
-        arg_string = ""
+    arg_string = get_infix_result_string(expr)
     return (
         f"{header}\n\n"
         f"{arg_string}"
@@ -709,15 +706,7 @@ def format_matrix_infix_expression(expr):
         name=name,
         quote=False,
     )
-    if config.get("autocompute") and (
-        expr.method_name not in {"ewise_add", "ewise_mult"}
-        or expr.left.dtype == BOOL
-        and expr.right.dtype == BOOL
-    ):
-        arg_string = get_expr_result(expr)
-        arg_string += "\n\n"
-    else:
-        arg_string = ""
+    arg_string = get_infix_result_string(expr)
     return (
         f"{header}\n\n"
         f"{arg_string}"

--- a/grblas/formatting.py
+++ b/grblas/formatting.py
@@ -310,8 +310,15 @@ def matrix_info(matrix, *, mask=None, for_html=True):
             name = [f"{type(mask).__name__}", f"of grblas.{type(matrix).__name__}"]
     else:
         name = f"grblas.{type(matrix).__name__}"
-    keys = ["nvals", "nrows", "ncols", "dtype"]
+    keys = ["nvals", "nrows", "ncols", "dtype", "format"]
     vals = [matrix._nvals, matrix._nrows, matrix._ncols, matrix.dtype.name]
+    # SS, SuiteSparse-specific: format (ends with "r" or "c")
+    if type(matrix) is Matrix:
+        vals.append(matrix.ss.format)
+    else:  # TransposedMatrix
+        fmt = matrix._matrix.ss.format
+        fmt = fmt[:-1] + ("c" if fmt[-1] == "r" else "r")
+        vals.append(fmt)
     return name, keys, vals
 
 
@@ -323,8 +330,9 @@ def vector_info(vector, *, mask=None, for_html=True):
             name = [f"{type(mask).__name__}", f"of grblas.{type(vector).__name__}"]
     else:
         name = f"grblas.{type(vector).__name__}"
-    keys = ["nvals", "size", "dtype"]
-    vals = [vector._nvals, vector._size, vector.dtype.name]
+    # SS, SuiteSparse-specific: format
+    keys = ["nvals", "size", "dtype", "format"]
+    vals = [vector._nvals, vector._size, vector.dtype.name, vector.ss.format]
     return name, keys, vals
 
 
@@ -351,9 +359,9 @@ def vector_header_html(vector, *, mask=None):
     return create_header_html(name, keys, vals)
 
 
-def _format_html(name, header, df):
+def _format_html(name, header, df, collapse):
     if has_pandas:
-        state = " open"
+        state = "" if collapse else " open"
         with pd.option_context("display.show_dimensions", False, "display.large_repr", "truncate"):
             details = df._repr_html_()
     else:
@@ -372,24 +380,28 @@ def _format_html(name, header, df):
     )
 
 
-def format_matrix_html(matrix, *, max_rows=None, min_rows=None, max_columns=None, mask=None):
+def format_matrix_html(
+    matrix, *, max_rows=None, min_rows=None, max_columns=None, mask=None, collapse=False
+):
     header = matrix_header_html(matrix, mask=mask)
     df = _get_matrix_dataframe(matrix, max_rows, min_rows, max_columns, mask=mask)
     if mask is None:
         name = matrix._name_html
     else:
         name = mask._name_html
-    return _format_html(name, header, df)
+    return _format_html(name, header, df, collapse)
 
 
-def format_vector_html(vector, *, max_rows=None, min_rows=None, max_columns=None, mask=None):
+def format_vector_html(
+    vector, *, max_rows=None, min_rows=None, max_columns=None, mask=None, collapse=False
+):
     header = vector_header_html(vector, mask=mask)
     df = _get_vector_dataframe(vector, max_rows, min_rows, max_columns, mask=mask)
     if mask is None:
         name = vector._name_html
     else:
         name = mask._name_html
-    return _format_html(name, header, df)
+    return _format_html(name, header, df, collapse)
 
 
 def format_scalar_html(scalar):
@@ -406,6 +418,24 @@ def format_scalar(scalar):
     )
 
 
+def get_expr_result(expr, html=False):
+    try:
+        val = expr._get_value()
+    except OutOfMemory:
+        arg_string = "Result is too large to compute!"
+        if html:
+            arg_string = f"<hr><b>{arg_string}</b>"
+    else:
+        name = val.name
+        val.name = "Result"
+        if html:
+            arg_string = f"<hr>{val._repr_html_()}"
+        else:
+            arg_string = f"{val}"
+        val.name = name
+    return arg_string
+
+
 def _format_expression(expr, header):
     pos_to_arg = {}
     for i, arg in enumerate(expr.args):
@@ -413,17 +443,9 @@ def _format_expression(expr, header):
         if pos >= 0:  # pragma: no branch
             pos_to_arg[pos] = arg
     args = [pos_to_arg[pos] for pos in sorted(pos_to_arg)]
-    arg_string = "".join(x._repr_html_() for x in args if hasattr(x, "_repr_html_"))
+    arg_string = "".join(x._repr_html_(collapse=True) for x in args if hasattr(x, "_repr_html_"))
     if config.get("autocompute"):
-        try:
-            val = expr._get_value()
-        except OutOfMemory:
-            arg_string += "<hr><b>Result is too large to compute!</b>"
-        else:
-            name = val.name
-            val.name = "Result"
-            arg_string += f"<hr>{val._repr_html_()}"
-            val.name = name
+        arg_string += get_expr_result(expr, html=True)
     return (
         "<div>"
         '<details class="gb-expr-details">'
@@ -460,7 +482,16 @@ def format_matrix_expression(expr):
         name=name,
         quote=False,
     )
-    return f"{header}\n\nDo expr.new() or other << expr to calculate the expression."
+    if config.get("autocompute"):
+        arg_string = get_expr_result(expr)
+        arg_string += "\n\n"
+    else:
+        arg_string = ""
+    return (
+        f"{header}\n\n"
+        f"{arg_string}"
+        "Do expr.new() or other << expr to calculate the expression."
+    )
 
 
 def format_vector_expression_html(expr):
@@ -475,7 +506,16 @@ def format_vector_expression(expr):
     header = create_header(
         expr_repr, ["size", "dtype"], [expr._size, expr.dtype], name=name, quote=False
     )
-    return f"{header}\n\nDo expr.new() or other << expr to calculate the expression."
+    if config.get("autocompute"):
+        arg_string = get_expr_result(expr)
+        arg_string += "\n\n"
+    else:
+        arg_string = ""
+    return (
+        f"{header}\n\n"
+        f"{arg_string}"
+        "Do expr.new() or other << expr to calculate the expression."
+    )
 
 
 def format_scalar_expression_html(expr):
@@ -488,7 +528,16 @@ def format_scalar_expression(expr):
     expr_repr = expr._format_expr()
     name = f"grblas.{type(expr).__name__}"
     header = create_header(expr_repr, ["dtype"], [expr.dtype], name=name, quote=False)
-    return f"{header}\n\nDo expr.new() or other << expr to calculate the expression."
+    if config.get("autocompute"):
+        arg_string = get_expr_result(expr)
+        arg_string += "\n\n"
+    else:
+        arg_string = ""
+    return (
+        f"{header}\n\n"
+        f"{arg_string}"
+        "Do expr.new() or other << expr to calculate the expression."
+    )
 
 
 def create_header(type_name, keys, vals, *, lower_border=False, name="", quote=True):
@@ -553,22 +602,13 @@ def format_vector(vector, *, max_rows=None, min_rows=None, max_columns=None, mas
 
 
 def _format_infix_expression(expr, header, expr_name):
-    arg_string = f"{expr.left._repr_html_()}{expr.right._repr_html_()}"
-    if config.get("autocompute"):
-        if (
-            expr.method_name not in {"ewise_add", "ewise_mult"}
-            or expr.left.dtype == BOOL
-            and expr.right.dtype == BOOL
-        ):
-            try:
-                val = expr._get_value()
-            except OutOfMemory:
-                arg_string += "<hr><b>Result is too large to compute!</b>"
-            else:
-                name = val.name
-                val.name = "Result"
-                arg_string += f"<hr>{val._repr_html_()}"
-                val.name = name
+    arg_string = f"{expr.left._repr_html_(collapse=True)}{expr.right._repr_html_(collapse=True)}"
+    if config.get("autocompute") and (
+        expr.method_name not in {"ewise_add", "ewise_mult"}
+        or expr.left.dtype == BOOL
+        and expr.right.dtype == BOOL
+    ):
+        arg_string += get_expr_result(expr, html=True)
     return (
         "<div>"
         '<details class="gb-expr-details">'
@@ -599,8 +639,14 @@ def format_scalar_infix_expression(expr):
         name=name,
         quote=False,
     )
+    if config.get("autocompute"):
+        arg_string = get_expr_result(expr)
+        arg_string += "\n\n"
+    else:
+        arg_string = ""
     return (
         f"{header}\n\n"
+        f"{arg_string}"
         f"Do op(expr) to create a {expr.output_type.__name__} for {expr.method_name}.\n"
         f"For example: {expr._example_op}({expr_repr})"
     )
@@ -626,8 +672,18 @@ def format_vector_infix_expression(expr):
         name=name,
         quote=False,
     )
+    if config.get("autocompute") and (
+        expr.method_name not in {"ewise_add", "ewise_mult"}
+        or expr.left.dtype == BOOL
+        and expr.right.dtype == BOOL
+    ):
+        arg_string = get_expr_result(expr)
+        arg_string += "\n\n"
+    else:
+        arg_string = ""
     return (
         f"{header}\n\n"
+        f"{arg_string}"
         f"Do op(expr) to create a {expr.output_type.__name__} for {expr.method_name}.\n"
         f"For example: {expr._example_op}({expr_repr})"
     )
@@ -653,8 +709,18 @@ def format_matrix_infix_expression(expr):
         name=name,
         quote=False,
     )
+    if config.get("autocompute") and (
+        expr.method_name not in {"ewise_add", "ewise_mult"}
+        or expr.left.dtype == BOOL
+        and expr.right.dtype == BOOL
+    ):
+        arg_string = get_expr_result(expr)
+        arg_string += "\n\n"
+    else:
+        arg_string = ""
     return (
         f"{header}\n\n"
+        f"{arg_string}"
         f"Do op(expr) to create a {expr.output_type.__name__} for {expr.method_name}.\n"
         f"For example: {expr._example_op}({expr_repr})"
     )

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -58,12 +58,12 @@ class Matrix(BaseType):
         with skip_record:
             return format_matrix(self, mask=mask)
 
-    def _repr_html_(self, mask=None):
+    def _repr_html_(self, mask=None, collapse=False):
         from .formatting import format_matrix_html
         from .recorder import skip_record
 
         with skip_record:
-            return format_matrix_html(self, mask=mask)
+            return format_matrix_html(self, mask=mask, collapse=collapse)
 
     def __reduce__(self):
         # SS, SuiteSparse-specific: export
@@ -1265,10 +1265,10 @@ class TransposedMatrix:
 
         return format_matrix(self)
 
-    def _repr_html_(self):
+    def _repr_html_(self, collapse=False):
         from .formatting import format_matrix_html
 
-        return format_matrix_html(self)
+        return format_matrix_html(self, collapse=collapse)
 
     def new(self, dtype=None, *, mask=None, name=None):
         if dtype is None:

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -34,7 +34,7 @@ class Scalar(BaseType):
 
         return format_scalar(self)
 
-    def _repr_html_(self):
+    def _repr_html_(self, collapse=False):
         from .formatting import format_scalar_html
 
         return format_scalar_html(self)
@@ -341,7 +341,7 @@ class _CScalar:
     def __repr__(self):
         return repr(self.scalar.value)
 
-    def _repr_html_(self):
+    def _repr_html_(self, collapse=False):
         return self.scalar._repr_html_()
 
     @property

--- a/grblas/tests/test_formatting.py
+++ b/grblas/tests/test_formatting.py
@@ -5785,18 +5785,18 @@ def test_autocompute(A, B, v):
     repr_printer(BIG_bool | small_bool, "BIG_bool | small_bool")
     assert repr(BIG_bool | small_bool) == (
         "grblas.VectorEwiseAddExpr               size  left_dtype  right_dtype\n"
-        "v_4 | v_5                  36028797018963968        BOOL         BOOL\n"
+        "v_6 | v_7                  36028797018963968        BOOL         BOOL\n"
         "\n"
         "Result is too large to compute!\n"
         "\n"
         "Do op(expr) to create a VectorExpression for ewise_add.\n"
-        "For example: plus(v_4 | v_5)"
+        "For example: plus(v_6 | v_7)"
     )
     C = A.dup(dtype=bool)
     repr_printer(C & C, "C & C")
     assert repr(C & C) == (
         "grblas.MatrixEwiseMultExpr  nrows  ncols  left_dtype  right_dtype\n"
-        "M_1 & M_1                       1      5        BOOL         BOOL\n"
+        "M_2 & M_2                       1      5        BOOL         BOOL\n"
         "\n"
         '"Result"       nvals  nrows  ncols  dtype   format\n'
         "grblas.Matrix      3      1      5   BOOL  bitmapr\n"
@@ -5805,7 +5805,7 @@ def test_autocompute(A, B, v):
         "0  False    True    True\n"
         "\n"
         "Do op(expr) to create a MatrixExpression for ewise_mult.\n"
-        "For example: times(M_1 & M_1)"
+        "For example: times(M_2 & M_2)"
     )
 
 

--- a/grblas/tests/test_formatting.py
+++ b/grblas/tests/test_formatting.py
@@ -5728,6 +5728,88 @@ def test_inner_outer_repr(v):
 
 
 @autocompute
+def test_autocompute(A, B, v):
+    if not pd:  # pragma: no cover
+        return
+    repr_printer(A & A, "A & A")
+    assert repr(A & A) == (
+        "grblas.MatrixEwiseMultExpr  nrows  ncols  left_dtype  right_dtype\n"
+        "A_1 & A_1                       1      5       INT64        INT64\n"
+        "\n"
+        "Do op(expr) to create a MatrixExpression for ewise_mult.\n"
+        "For example: times(A_1 & A_1)"
+    )
+    repr_printer(A.ewise_add(A), "A.ewise_add(A)")
+    assert repr(A.ewise_add(A)) == (
+        "grblas.MatrixExpression                    nrows  ncols  dtype\n"
+        "A_1.ewise_add(A_1, op=monoid.plus[INT64])      1      5  INT64\n"
+        "\n"
+        '"Result"       nvals  nrows  ncols  dtype   format\n'
+        "grblas.Matrix      3      1      5  INT64  bitmapr\n"
+        "--------------------------------------------------\n"
+        "   0 1  2 3  4\n"
+        "0  0    2    4\n"
+        "\n"
+        "Do expr.new() or other << expr to calculate the expression."
+    )
+
+    BIG = Vector.new(int, size=2 ** 55)
+    small = Vector.new(int, size=2 ** 55)
+    BIG[:] = 1
+    small[0] = 2
+    repr_printer(BIG.ewise_mult(small), "BIG.ewise_mult(small)")
+    assert repr(BIG.ewise_mult(small)) == (
+        "grblas.VectorExpression                                   size  dtype\n"
+        "v_0.ewise_mult(v_1, op=binary.times[INT64])  36028797018963968  INT64\n"
+        "\n"
+        '"Result"       nvals               size  dtype  format\n'
+        "grblas.Vector      1  36028797018963968  INT64  sparse\n"
+        "------------------------------------------------------\n"
+        " 0                 1                  ... 36028797018963966 36028797018963967\n"
+        "                 2                    ...                                    \n"
+        "\n"
+        "Do expr.new() or other << expr to calculate the expression."
+    )
+    repr_printer(BIG.ewise_add(small), "BIG.ewise_add(small)")
+    assert repr(BIG.ewise_add(small)) == (
+        "grblas.VectorExpression                                 size  dtype\n"
+        "v_0.ewise_add(v_1, op=monoid.plus[INT64])  36028797018963968  INT64\n"
+        "\n"
+        "Result is too large to compute!\n"
+        "\n"
+        "Do expr.new() or other << expr to calculate the expression."
+    )
+    BIG_bool = BIG.dup(dtype=bool)
+    small_bool = small.dup(dtype=bool)
+    small_bool[0] = False
+    repr_printer(BIG_bool | small_bool, "BIG_bool | small_bool")
+    assert repr(BIG_bool | small_bool) == (
+        "grblas.VectorEwiseAddExpr               size  left_dtype  right_dtype\n"
+        "v_4 | v_5                  36028797018963968        BOOL         BOOL\n"
+        "\n"
+        "Result is too large to compute!\n"
+        "\n"
+        "Do op(expr) to create a VectorExpression for ewise_add.\n"
+        "For example: plus(v_4 | v_5)"
+    )
+    C = A.dup(dtype=bool)
+    repr_printer(C & C, "C & C")
+    assert repr(C & C) == (
+        "grblas.MatrixEwiseMultExpr  nrows  ncols  left_dtype  right_dtype\n"
+        "M_1 & M_1                       1      5        BOOL         BOOL\n"
+        "\n"
+        '"Result"       nvals  nrows  ncols  dtype   format\n'
+        "grblas.Matrix      3      1      5   BOOL  bitmapr\n"
+        "--------------------------------------------------\n"
+        "       0 1     2 3     4\n"
+        "0  False    True    True\n"
+        "\n"
+        "Do op(expr) to create a MatrixExpression for ewise_mult.\n"
+        "For example: times(M_1 & M_1)"
+    )
+
+
+@autocompute
 def test_autocompute_html(A, B, v):
     if not pd:  # pragma: no cover
         return

--- a/grblas/tests/test_formatting.py
+++ b/grblas/tests/test_formatting.py
@@ -136,29 +136,30 @@ def test_no_pandas_repr(A, C, v, w):
     try:
         repr_printer(A, "A", indent=8)
         assert repr(A) == (
-            '"A_1"          nvals  nrows  ncols  dtype\n'
-            "grblas.Matrix      3      1      5  INT64"
+            '"A_1"          nvals  nrows  ncols  dtype   format\n'
+            "grblas.Matrix      3      1      5  INT64  bitmapr"
         )
         repr_printer(A.T, "A.T", indent=8)
         assert repr(A.T) == (
-            '"A_1.T"                  nvals  nrows  ncols  dtype\n'
-            "grblas.TransposedMatrix      3      5      1  INT64"
+            '"A_1.T"                  nvals  nrows  ncols  dtype   format\n'
+            "grblas.TransposedMatrix      3      5      1  INT64  bitmapc"
         )
         repr_printer(C.S, "C.S", indent=8)
         assert repr(C.S) == (
-            '"C.S"             nvals  nrows  ncols  dtype\n'
+            '"C.S"             nvals  nrows  ncols  dtype    format\n'
             "StructuralMask  \n"
-            "of grblas.Matrix      8     70     77  INT64"
+            "of grblas.Matrix      8     70     77  INT64  hypercsr"
         )
         repr_printer(v, "v", indent=8)
         assert repr(v) == (
-            '"v"            nvals  size  dtype\n' "grblas.Vector      3     5   FP64"
+            '"v"            nvals  size  dtype  format\n'
+            "grblas.Vector      3     5   FP64  bitmap"
         )
         repr_printer(~w.V, "~w.V", indent=8)
         assert repr(~w.V) == (
-            '"~w.V"                 nvals  size  dtype\n'
+            '"~w.V"                 nvals  size  dtype  format\n'
             "ComplementedValueMask\n"
-            "of grblas.Vector           4    77  INT64"
+            "of grblas.Vector           4    77  INT64  bitmap"
         )
     finally:
         formatting.has_pandas = has_pandas_prev
@@ -168,17 +169,17 @@ def test_no_pandas_repr(A, C, v, w):
 def test_matrix_repr_small(A, B):
     repr_printer(A, "A")
     assert repr(A) == (
-        '"A_1"          nvals  nrows  ncols  dtype\n'
-        "grblas.Matrix      3      1      5  INT64\n"
-        "-----------------------------------------\n"
+        '"A_1"          nvals  nrows  ncols  dtype   format\n'
+        "grblas.Matrix      3      1      5  INT64  bitmapr\n"
+        "--------------------------------------------------\n"
         "   0 1  2 3  4\n"
         "0  0    1    2"
     )
     repr_printer(B, "B")
     assert repr(B) == (
-        '"B_1"          nvals  nrows  ncols  dtype\n'
-        "grblas.Matrix      3      5      1  INT64\n"
-        "-----------------------------------------\n"
+        '"B_1"          nvals  nrows  ncols  dtype   format\n'
+        "grblas.Matrix      3      5      1  INT64  bitmapr\n"
+        "--------------------------------------------------\n"
         "    0\n"
         "0  10\n"
         "1    \n"
@@ -188,9 +189,9 @@ def test_matrix_repr_small(A, B):
     )
     repr_printer(B.T, "B.T")
     assert repr(B.T) == (
-        '"B_1.T"                  nvals  nrows  ncols  dtype\n'
-        "grblas.TransposedMatrix      3      1      5  INT64\n"
-        "---------------------------------------------------\n"
+        '"B_1.T"                  nvals  nrows  ncols  dtype   format\n'
+        "grblas.TransposedMatrix      3      1      5  INT64  bitmapc\n"
+        "------------------------------------------------------------\n"
         "    0 1   2 3   4\n"
         "0  10    20    30"
     )
@@ -200,37 +201,37 @@ def test_matrix_repr_small(A, B):
 def test_matrix_mask_repr_small(A):
     repr_printer(A.S, "A.S")
     assert repr(A.S) == (
-        '"A_1.S"           nvals  nrows  ncols  dtype\n'
+        '"A_1.S"           nvals  nrows  ncols  dtype   format\n'
         "StructuralMask  \n"
-        "of grblas.Matrix      3      1      5  INT64\n"
-        "--------------------------------------------\n"
+        "of grblas.Matrix      3      1      5  INT64  bitmapr\n"
+        "-----------------------------------------------------\n"
         "   0 1  2 3  4\n"
         "0  1    1    1"
     )
     repr_printer(A.V, "A.V")
     assert repr(A.V) == (
-        '"A_1.V"           nvals  nrows  ncols  dtype\n'
+        '"A_1.V"           nvals  nrows  ncols  dtype   format\n'
         "ValueMask       \n"
-        "of grblas.Matrix      3      1      5  INT64\n"
-        "--------------------------------------------\n"
+        "of grblas.Matrix      3      1      5  INT64  bitmapr\n"
+        "-----------------------------------------------------\n"
         "   0 1  2 3  4\n"
         "0  0    1    1"
     )
     repr_printer(~A.S, "~A.S")
     assert repr(~A.S) == (
-        '"~A_1.S"                    nvals  nrows  ncols  dtype\n'
+        '"~A_1.S"                    nvals  nrows  ncols  dtype   format\n'
         "ComplementedStructuralMask\n"
-        "of grblas.Matrix                3      1      5  INT64\n"
-        "------------------------------------------------------\n"
+        "of grblas.Matrix                3      1      5  INT64  bitmapr\n"
+        "---------------------------------------------------------------\n"
         "   0 1  2 3  4\n"
         "0  0    0    0"
     )
     repr_printer(~A.V, "~A.V")
     assert repr(~A.V) == (
-        '"~A_1.V"               nvals  nrows  ncols  dtype\n'
+        '"~A_1.V"               nvals  nrows  ncols  dtype   format\n'
         "ComplementedValueMask\n"
-        "of grblas.Matrix           3      1      5  INT64\n"
-        "-------------------------------------------------\n"
+        "of grblas.Matrix           3      1      5  INT64  bitmapr\n"
+        "----------------------------------------------------------\n"
         "   0 1  2 3  4\n"
         "0  1    0    0"
     )
@@ -241,9 +242,9 @@ def test_matrix_repr_large(C, D):
     with pd.option_context("display.max_columns", 24, "display.width", 100):
         repr_printer(C, "C", indent=8)
         assert repr(C) == (
-            '"C"            nvals  nrows  ncols  dtype\n'
-            "grblas.Matrix      8     70     77  INT64\n"
-            "-----------------------------------------\n"
+            '"C"            nvals  nrows  ncols  dtype    format\n'
+            "grblas.Matrix      8     70     77  INT64  hypercsr\n"
+            "---------------------------------------------------\n"
             "   0  1  2  3  4  5  6  7  8  9  10 11  ... 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "0               0                       ...                       5            \n"
             "1                                       ...                                    \n"
@@ -259,9 +260,9 @@ def test_matrix_repr_large(C, D):
         )
         repr_printer(C.T, "C.T", indent=8)
         assert repr(C.T) == (
-            '"C.T"                    nvals  nrows  ncols  dtype\n'
-            "grblas.TransposedMatrix      8     77     70  INT64\n"
-            "---------------------------------------------------\n"
+            '"C.T"                    nvals  nrows  ncols  dtype    format\n'
+            "grblas.TransposedMatrix      8     77     70  INT64  hypercsc\n"
+            "-------------------------------------------------------------\n"
             "   0  1  2  3  4  5  6  7  8  9  10 11  ... 58 59 60 61 62 63 64 65 66 67 68 69\n"
             "0                                       ...                                    \n"
             "1                                       ...                                    \n"
@@ -277,9 +278,9 @@ def test_matrix_repr_large(C, D):
         )
         repr_printer(D, "D", indent=8)
         assert repr(D) == (
-            '"D_skinny_in_one_dim"  nvals  nrows  ncols  dtype\n'
-            "grblas.Matrix              4     70      5   BOOL\n"
-            "-------------------------------------------------\n"
+            '"D_skinny_in_one_dim"  nvals  nrows  ncols  dtype    format\n'
+            "grblas.Matrix              4     70      5   BOOL  hypercsr\n"
+            "-----------------------------------------------------------\n"
             "   0  1  2  3       4\n"
             "0                True\n"
             "1                    \n"
@@ -295,9 +296,9 @@ def test_matrix_repr_large(C, D):
         )
         repr_printer(D.T, "D.T", indent=8)
         assert repr(D.T) == (
-            '"D_skinny_in_one_dim.T"  nvals  nrows  ncols  dtype\n'
-            "grblas.TransposedMatrix      4      5     70   BOOL\n"
-            "---------------------------------------------------\n"
+            '"D_skinny_in_one_dim.T"  nvals  nrows  ncols  dtype    format\n'
+            "grblas.TransposedMatrix      4      5     70   BOOL  hypercsc\n"
+            "-------------------------------------------------------------\n"
             "     0  1  2  3  4  5  6  7  8      9  10 11  ... 58 59    60 61 62 63 64 65 66 67 68     69\n"
             "0                                             ...                                           \n"
             "1                                             ...                                           \n"
@@ -312,10 +313,10 @@ def test_matrix_mask_repr_large(C):
     with pd.option_context("display.max_columns", 24, "display.width", 100):
         repr_printer(C.S, "C.S", indent=8)
         assert repr(C.S) == (
-            '"C.S"             nvals  nrows  ncols  dtype\n'
+            '"C.S"             nvals  nrows  ncols  dtype    format\n'
             "StructuralMask  \n"
-            "of grblas.Matrix      8     70     77  INT64\n"
-            "--------------------------------------------\n"
+            "of grblas.Matrix      8     70     77  INT64  hypercsr\n"
+            "------------------------------------------------------\n"
             "   0  1  2  3  4  5  6  7  8  9  10 11  ... 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "0               1                       ...                       1            \n"
             "1                                       ...                                    \n"
@@ -331,10 +332,10 @@ def test_matrix_mask_repr_large(C):
         )
         repr_printer(C.V, "C.V", indent=8)
         assert repr(C.V) == (
-            '"C.V"             nvals  nrows  ncols  dtype\n'
+            '"C.V"             nvals  nrows  ncols  dtype    format\n'
             "ValueMask       \n"
-            "of grblas.Matrix      8     70     77  INT64\n"
-            "--------------------------------------------\n"
+            "of grblas.Matrix      8     70     77  INT64  hypercsr\n"
+            "------------------------------------------------------\n"
             "   0  1  2  3  4  5  6  7  8  9  10 11  ... 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "0               0                       ...                       1            \n"
             "1                                       ...                                    \n"
@@ -350,10 +351,10 @@ def test_matrix_mask_repr_large(C):
         )
         repr_printer(~C.S, "~C.S", indent=8)
         assert repr(~C.S) == (
-            '"~C.S"                      nvals  nrows  ncols  dtype\n'
+            '"~C.S"                      nvals  nrows  ncols  dtype    format\n'
             "ComplementedStructuralMask\n"
-            "of grblas.Matrix                8     70     77  INT64\n"
-            "------------------------------------------------------\n"
+            "of grblas.Matrix                8     70     77  INT64  hypercsr\n"
+            "----------------------------------------------------------------\n"
             "   0  1  2  3  4  5  6  7  8  9  10 11  ... 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "0               0                       ...                       0            \n"
             "1                                       ...                                    \n"
@@ -369,10 +370,10 @@ def test_matrix_mask_repr_large(C):
         )
         repr_printer(~C.V, "~C.V", indent=8)
         assert repr(~C.V) == (
-            '"~C.V"                 nvals  nrows  ncols  dtype\n'
+            '"~C.V"                 nvals  nrows  ncols  dtype    format\n'
             "ComplementedValueMask\n"
-            "of grblas.Matrix           8     70     77  INT64\n"
-            "-------------------------------------------------\n"
+            "of grblas.Matrix           8     70     77  INT64  hypercsr\n"
+            "-----------------------------------------------------------\n"
             "   0  1  2  3  4  5  6  7  8  9  10 11  ... 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "0               1                       ...                       0            \n"
             "1                                       ...                                    \n"
@@ -392,9 +393,9 @@ def test_matrix_mask_repr_large(C):
 def test_vector_repr_small(v):
     repr_printer(v, "v")
     assert repr(v) == (
-        '"v"            nvals  size  dtype\n'
-        "grblas.Vector      3     5   FP64\n"
-        "---------------------------------\n"
+        '"v"            nvals  size  dtype  format\n'
+        "grblas.Vector      3     5   FP64  bitmap\n"
+        "-----------------------------------------\n"
         "    0 1    2 3    4\n"
         "  0.0    1.1    2.2"
     )
@@ -405,9 +406,9 @@ def test_vector_repr_large(w):
     with pd.option_context("display.max_columns", 26, "display.width", 100):
         repr_printer(w, "w", indent=8)
         assert repr(w) == (
-            '"w"            nvals  size  dtype\n'
-            "grblas.Vector      4    77  INT64\n"
-            "---------------------------------\n"
+            '"w"            nvals  size  dtype  format\n'
+            "grblas.Vector      4    77  INT64  bitmap\n"
+            "-----------------------------------------\n"
             " 0  1  2  3  4  5  6  7  8  9  10 11 12  ... 64 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "  1              2                       ...  3              4                     "
         )
@@ -417,37 +418,37 @@ def test_vector_repr_large(w):
 def test_vector_mask_repr_small(v):
     repr_printer(v.S, "v.S")
     assert repr(v.S) == (
-        '"v.S"             nvals  size  dtype\n'
+        '"v.S"             nvals  size  dtype  format\n'
         "StructuralMask  \n"
-        "of grblas.Vector      3     5   FP64\n"
-        "------------------------------------\n"
+        "of grblas.Vector      3     5   FP64  bitmap\n"
+        "--------------------------------------------\n"
         "  0 1  2 3  4\n"
         "  1    1    1"
     )
     repr_printer(v.V, "v.V")
     assert repr(v.V) == (
-        '"v.V"             nvals  size  dtype\n'
+        '"v.V"             nvals  size  dtype  format\n'
         "ValueMask       \n"
-        "of grblas.Vector      3     5   FP64\n"
-        "------------------------------------\n"
+        "of grblas.Vector      3     5   FP64  bitmap\n"
+        "--------------------------------------------\n"
         "  0 1  2 3  4\n"
         "  0    1    1"
     )
     repr_printer(~v.S, "~v.S")
     assert repr(~v.S) == (
-        '"~v.S"                      nvals  size  dtype\n'
+        '"~v.S"                      nvals  size  dtype  format\n'
         "ComplementedStructuralMask\n"
-        "of grblas.Vector                3     5   FP64\n"
-        "----------------------------------------------\n"
+        "of grblas.Vector                3     5   FP64  bitmap\n"
+        "------------------------------------------------------\n"
         "  0 1  2 3  4\n"
         "  0    0    0"
     )
     repr_printer(~v.V, "~v.V")
     assert repr(~v.V) == (
-        '"~v.V"                 nvals  size  dtype\n'
+        '"~v.V"                 nvals  size  dtype  format\n'
         "ComplementedValueMask\n"
-        "of grblas.Vector           3     5   FP64\n"
-        "-----------------------------------------\n"
+        "of grblas.Vector           3     5   FP64  bitmap\n"
+        "-------------------------------------------------\n"
         "  0 1  2 3  4\n"
         "  1    0    0"
     )
@@ -458,37 +459,37 @@ def test_vector_mask_repr_large(w):
     with pd.option_context("display.max_columns", 26, "display.width", 100):
         repr_printer(w.S, "w.S", indent=8)
         assert repr(w.S) == (
-            '"w.S"             nvals  size  dtype\n'
+            '"w.S"             nvals  size  dtype  format\n'
             "StructuralMask  \n"
-            "of grblas.Vector      4    77  INT64\n"
-            "------------------------------------\n"
+            "of grblas.Vector      4    77  INT64  bitmap\n"
+            "--------------------------------------------\n"
             " 0  1  2  3  4  5  6  7  8  9  10 11 12  ... 64 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "  1              1                       ...  1              1                     "
         )
         repr_printer(w.V, "w.V", indent=8)
         assert repr(w.V) == (
-            '"w.V"             nvals  size  dtype\n'
+            '"w.V"             nvals  size  dtype  format\n'
             "ValueMask       \n"
-            "of grblas.Vector      4    77  INT64\n"
-            "------------------------------------\n"
+            "of grblas.Vector      4    77  INT64  bitmap\n"
+            "--------------------------------------------\n"
             " 0  1  2  3  4  5  6  7  8  9  10 11 12  ... 64 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "  1              1                       ...  1              1                     "
         )
         repr_printer(~w.S, "~w.S", indent=8)
         assert repr(~w.S) == (
-            '"~w.S"                      nvals  size  dtype\n'
+            '"~w.S"                      nvals  size  dtype  format\n'
             "ComplementedStructuralMask\n"
-            "of grblas.Vector                4    77  INT64\n"
-            "----------------------------------------------\n"
+            "of grblas.Vector                4    77  INT64  bitmap\n"
+            "------------------------------------------------------\n"
             " 0  1  2  3  4  5  6  7  8  9  10 11 12  ... 64 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "  0              0                       ...  0              0                     "
         )
         repr_printer(~w.V, "~w.V", indent=8)
         assert repr(~w.V) == (
-            '"~w.V"                 nvals  size  dtype\n'
+            '"~w.V"                 nvals  size  dtype  format\n'
             "ComplementedValueMask\n"
-            "of grblas.Vector           4    77  INT64\n"
-            "-----------------------------------------\n"
+            "of grblas.Vector           4    77  INT64  bitmap\n"
+            "-------------------------------------------------\n"
             " 0  1  2  3  4  5  6  7  8  9  10 11 12  ... 64 65 66 67 68 69 70 71 72 73 74 75 76\n"
             "  0              0                       ...  0              0                     "
         )
@@ -517,12 +518,14 @@ def test_no_pandas_repr_html(A, C, v, w):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>3</td>\n"
             "    <td>1</td>\n"
             "    <td>5</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmapr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -540,12 +543,14 @@ def test_no_pandas_repr_html(A, C, v, w):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>3</td>\n"
             "    <td>5</td>\n"
             "    <td>1</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmapc</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -565,12 +570,14 @@ def test_no_pandas_repr_html(A, C, v, w):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>70</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -587,11 +594,13 @@ def test_no_pandas_repr_html(A, C, v, w):
             "    <td><pre>nvals</pre></td>\n"
             "    <td><pre>size</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>3</td>\n"
             "    <td>5</td>\n"
             "    <td>FP64</td>\n"
+            "    <td>bitmap</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -610,11 +619,13 @@ def test_no_pandas_repr_html(A, C, v, w):
             "    <td><pre>nvals</pre></td>\n"
             "    <td><pre>size</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmap</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -638,12 +649,14 @@ def test_matrix_repr_html_small(A, B):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -697,12 +710,14 @@ def test_matrix_repr_html_small(A, B):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>1</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -764,12 +779,14 @@ def test_matrix_repr_html_small(A, B):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapc</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -829,12 +846,14 @@ def test_matrix_mask_repr_html_small(A):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -890,12 +909,14 @@ def test_matrix_mask_repr_html_small(A):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -951,12 +972,14 @@ def test_matrix_mask_repr_html_small(A):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -1012,12 +1035,14 @@ def test_matrix_mask_repr_html_small(A):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -1076,12 +1101,14 @@ def test_matrix_repr_html_large(C, D):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>70</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -1213,12 +1240,14 @@ def test_matrix_repr_html_large(C, D):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>77</td>\n"
             "    <td>70</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsc</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -1342,12 +1371,14 @@ def test_matrix_repr_html_large(C, D):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>70</td>\n"
             "    <td>5</td>\n"
             "    <td>BOOL</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -1417,12 +1448,14 @@ def test_matrix_repr_html_large(C, D):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>5</td>\n"
             "    <td>70</td>\n"
             "    <td>BOOL</td>\n"
+            "    <td>hypercsc</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -1521,12 +1554,14 @@ def test_matrix_mask_repr_html_large(C):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>70</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -1660,12 +1695,14 @@ def test_matrix_mask_repr_html_large(C):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>70</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -1799,12 +1836,14 @@ def test_matrix_mask_repr_html_large(C):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>70</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -1938,12 +1977,14 @@ def test_matrix_mask_repr_html_large(C):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>70</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -2078,11 +2119,13 @@ def test_vector_repr_html_small(v):
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -2140,11 +2183,13 @@ def test_vector_repr_html_large(w):
             "    <td><pre>nvals</pre></td>\n"
             "    <td><pre>size</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmap</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -2222,11 +2267,13 @@ def test_vector_mask_repr_html_small(v):
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -2281,11 +2328,13 @@ def test_vector_mask_repr_html_small(v):
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -2340,11 +2389,13 @@ def test_vector_mask_repr_html_small(v):
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -2399,11 +2450,13 @@ def test_vector_mask_repr_html_small(v):
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -2463,11 +2516,13 @@ def test_vector_mask_repr_html_large(w):
             "    <td><pre>nvals</pre></td>\n"
             "    <td><pre>size</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmap</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -2541,11 +2596,13 @@ def test_vector_mask_repr_html_large(w):
             "    <td><pre>nvals</pre></td>\n"
             "    <td><pre>size</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmap</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -2619,11 +2676,13 @@ def test_vector_mask_repr_html_large(w):
             "    <td><pre>nvals</pre></td>\n"
             "    <td><pre>size</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmap</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -2697,11 +2756,13 @@ def test_vector_mask_repr_html_large(w):
             "    <td><pre>nvals</pre></td>\n"
             "    <td><pre>size</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>4</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>bitmap</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -2830,18 +2891,20 @@ def test_apply_repr_html(v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -2913,7 +2976,7 @@ def test_mxm_repr_html(A, B):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -2921,12 +2984,14 @@ def test_mxm_repr_html(A, B):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -2968,7 +3033,7 @@ def test_mxm_repr_html(A, B):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -2976,12 +3041,14 @@ def test_mxm_repr_html(A, B):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>1</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -3062,7 +3129,7 @@ def test_mxv_repr_html(A, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -3070,12 +3137,14 @@ def test_mxv_repr_html(A, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -3117,18 +3186,20 @@ def test_mxv_repr_html(A, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -3192,7 +3263,7 @@ def test_matrix_reduce_columns_repr_html(A):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -3200,12 +3271,14 @@ def test_matrix_reduce_columns_repr_html(A):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -3277,7 +3350,7 @@ def test_matrix_reduce_repr_html(C, v):
             "</div>\n"
             '</summary><blockquote class="gb-expr-blockquote"><div>'
             f"{CSS_STYLE}"
-            '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>C</tt><div>\n'
+            '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>C</tt><div>\n'
             '<table class="gb-info-table">\n'
             "  <tr>\n"
             '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -3285,12 +3358,14 @@ def test_matrix_reduce_repr_html(C, v):
             "    <td><pre>nrows</pre></td>\n"
             "    <td><pre>ncols</pre></td>\n"
             "    <td><pre>dtype</pre></td>\n"
+            "    <td><pre>format</pre></td>\n"
             "  </tr>\n"
             "  <tr>\n"
             "    <td>8</td>\n"
             "    <td>70</td>\n"
             "    <td>77</td>\n"
             "    <td>INT64</td>\n"
+            "    <td>hypercsr</td>\n"
             "  </tr>\n"
             "</table>\n"
             "</div>\n"
@@ -3417,9 +3492,9 @@ def test_matrix_huge():
     M = Matrix.new(int, nrows=2 ** 60, ncols=2 ** 60, name="M")
     repr_printer(M, "M")
     assert repr(M) == (
-        '"M"            nvals                nrows                ncols  dtype\n'
-        "grblas.Matrix      0  1152921504606846976  1152921504606846976  INT64\n"
-        "---------------------------------------------------------------------\n"
+        '"M"            nvals                nrows                ncols  dtype    format\n'
+        "grblas.Matrix      0  1152921504606846976  1152921504606846976  INT64  hypercsr\n"
+        "-------------------------------------------------------------------------------\n"
         "                    0                    ... 1152921504606846975\n"
         "0                                        ...                    \n"
         "1                                        ...                    \n"
@@ -3453,9 +3528,11 @@ def test_matrix_huge_html():
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>0</td>\n" + "    <td>1152921504606846976</td>\n" * 2 + "    <td>INT64</td>\n"
+        "    <td>hypercsr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -3634,9 +3711,9 @@ def test_vector_huge():
     v = Vector.new(int, size=2 ** 60)
     repr_printer(v, "v")
     assert repr(v) == (
-        '"v_0"          nvals                 size  dtype\n'
-        "grblas.Vector      0  1152921504606846976  INT64\n"
-        "------------------------------------------------\n"
+        '"v_0"          nvals                 size  dtype  format\n'
+        "grblas.Vector      0  1152921504606846976  INT64  sparse\n"
+        "--------------------------------------------------------\n"
         " 0                    ... 1152921504606846975\n"
         "                      ...                    "
     )
@@ -3658,11 +3735,13 @@ def test_vector_huge_html():
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>0</td>\n"
         "    <td>1152921504606846976</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>sparse</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -3785,9 +3864,9 @@ def test_sparse_vector_repr():
     v = Vector.from_values([100 * i for i in range(100)], [10 * i for i in range(100)], name="v")
     repr_printer(v, "v")
     assert repr(v) == (
-        '"v"            nvals  size  dtype\n'
-        "grblas.Vector    100  9901  INT64\n"
-        "---------------------------------\n"
+        '"v"            nvals  size  dtype  format\n'
+        "grblas.Vector    100  9901  INT64  sparse\n"
+        "-----------------------------------------\n"
         "    index  val\n"
         "0       0    0\n"
         "1     100   10\n"
@@ -3803,10 +3882,10 @@ def test_sparse_vector_repr():
     )
     repr_printer(v.S, "v.S")
     assert repr(v.S) == (
-        '"v.S"             nvals  size  dtype\n'
+        '"v.S"             nvals  size  dtype  format\n'
         "StructuralMask  \n"
-        "of grblas.Vector    100  9901  INT64\n"
-        "------------------------------------\n"
+        "of grblas.Vector    100  9901  INT64  sparse\n"
+        "--------------------------------------------\n"
         "    index  val\n"
         "0       0    1\n"
         "1     100    1\n"
@@ -3822,10 +3901,10 @@ def test_sparse_vector_repr():
     )
     repr_printer(~v.S, "~v.S")
     assert repr(~v.S) == (
-        '"~v.S"                      nvals  size  dtype\n'
+        '"~v.S"                      nvals  size  dtype  format\n'
         "ComplementedStructuralMask\n"
-        "of grblas.Vector              100  9901  INT64\n"
-        "----------------------------------------------\n"
+        "of grblas.Vector              100  9901  INT64  sparse\n"
+        "------------------------------------------------------\n"
         "    index  val\n"
         "0       0    0\n"
         "1     100    0\n"
@@ -3841,10 +3920,10 @@ def test_sparse_vector_repr():
     )
     repr_printer(v.V, "v.V")
     assert repr(v.V) == (
-        '"v.V"             nvals  size  dtype\n'
+        '"v.V"             nvals  size  dtype  format\n'
         "ValueMask       \n"
-        "of grblas.Vector    100  9901  INT64\n"
-        "------------------------------------\n"
+        "of grblas.Vector    100  9901  INT64  sparse\n"
+        "--------------------------------------------\n"
         "    index  val\n"
         "0     100    1\n"
         "1     200    1\n"
@@ -3860,10 +3939,10 @@ def test_sparse_vector_repr():
     )
     repr_printer(~v.V, "~v.V")
     assert repr(~v.V) == (
-        '"~v.V"                 nvals  size  dtype\n'
+        '"~v.V"                 nvals  size  dtype  format\n'
         "ComplementedValueMask\n"
-        "of grblas.Vector         100  9901  INT64\n"
-        "-----------------------------------------\n"
+        "of grblas.Vector         100  9901  INT64  sparse\n"
+        "-------------------------------------------------\n"
         "    index  val\n"
         "0     100    0\n"
         "1     200    0\n"
@@ -3880,9 +3959,9 @@ def test_sparse_vector_repr():
     v2 = v[:2000].new(name="v2")
     repr_printer(v2, "v2")
     assert repr(v2) == (
-        '"v2"           nvals  size  dtype\n'
-        "grblas.Vector     20  2000  INT64\n"
-        "---------------------------------\n"
+        '"v2"           nvals  size  dtype  format\n'
+        "grblas.Vector     20  2000  INT64  sparse\n"
+        "-----------------------------------------\n"
         "    index  val\n"
         "0       0    0\n"
         "1     100   10\n"
@@ -3907,10 +3986,10 @@ def test_sparse_vector_repr():
     )
     repr_printer(v2.V, "v2.V")
     assert repr(v2.V) == (
-        '"v2.V"            nvals  size  dtype\n'
+        '"v2.V"            nvals  size  dtype  format\n'
         "ValueMask       \n"
-        "of grblas.Vector     20  2000  INT64\n"
-        "------------------------------------\n"
+        "of grblas.Vector     20  2000  INT64  sparse\n"
+        "--------------------------------------------\n"
         "    index  val\n"
         "0     100    1\n"
         "1     200    1\n"
@@ -3941,9 +4020,9 @@ def test_sparse_matrix_repr():
     )
     repr_printer(A, "A")
     assert repr(A) == (
-        '"A"            nvals  nrows  ncols  dtype\n'
-        "grblas.Matrix    100   9901    991  INT64\n"
-        "-----------------------------------------\n"
+        '"A"            nvals  nrows  ncols  dtype    format\n'
+        "grblas.Matrix    100   9901    991  INT64  hypercsr\n"
+        "---------------------------------------------------\n"
         "     row  col  val\n"
         "0      0    0    0\n"
         "1    100   10    1\n"
@@ -3959,9 +4038,9 @@ def test_sparse_matrix_repr():
     )
     repr_printer(A.T, "A.T")
     assert repr(A.T) == (
-        '"A.T"                    nvals  nrows  ncols  dtype\n'
-        "grblas.TransposedMatrix    100    991   9901  INT64\n"
-        "---------------------------------------------------\n"
+        '"A.T"                    nvals  nrows  ncols  dtype    format\n'
+        "grblas.TransposedMatrix    100    991   9901  INT64  hypercsc\n"
+        "-------------------------------------------------------------\n"
         "     row  col  val\n"
         "0      0    0    0\n"
         "1     10  100    1\n"
@@ -3977,10 +4056,10 @@ def test_sparse_matrix_repr():
     )
     repr_printer(A.S, "A.S")
     assert repr(A.S) == (
-        '"A.S"             nvals  nrows  ncols  dtype\n'
+        '"A.S"             nvals  nrows  ncols  dtype    format\n'
         "StructuralMask  \n"
-        "of grblas.Matrix    100   9901    991  INT64\n"
-        "--------------------------------------------\n"
+        "of grblas.Matrix    100   9901    991  INT64  hypercsr\n"
+        "------------------------------------------------------\n"
         "     row  col  val\n"
         "0      0    0    1\n"
         "1    100   10    1\n"
@@ -3996,10 +4075,10 @@ def test_sparse_matrix_repr():
     )
     repr_printer(~A.S, "~A.S")
     assert repr(~A.S) == (
-        '"~A.S"                      nvals  nrows  ncols  dtype\n'
+        '"~A.S"                      nvals  nrows  ncols  dtype    format\n'
         "ComplementedStructuralMask\n"
-        "of grblas.Matrix              100   9901    991  INT64\n"
-        "------------------------------------------------------\n"
+        "of grblas.Matrix              100   9901    991  INT64  hypercsr\n"
+        "----------------------------------------------------------------\n"
         "     row  col  val\n"
         "0      0    0    0\n"
         "1    100   10    0\n"
@@ -4015,10 +4094,10 @@ def test_sparse_matrix_repr():
     )
     repr_printer(A.V, "A.V")
     assert repr(A.V) == (
-        '"A.V"             nvals  nrows  ncols  dtype\n'
+        '"A.V"             nvals  nrows  ncols  dtype    format\n'
         "ValueMask       \n"
-        "of grblas.Matrix    100   9901    991  INT64\n"
-        "--------------------------------------------\n"
+        "of grblas.Matrix    100   9901    991  INT64  hypercsr\n"
+        "------------------------------------------------------\n"
         "      row  col  val\n"
         "0     100   10    1\n"
         "1     200   20    1\n"
@@ -4034,10 +4113,10 @@ def test_sparse_matrix_repr():
     )
     repr_printer(~A.V, "~A.V")
     assert repr(~A.V) == (
-        '"~A.V"                 nvals  nrows  ncols  dtype\n'
+        '"~A.V"                 nvals  nrows  ncols  dtype    format\n'
         "ComplementedValueMask\n"
-        "of grblas.Matrix         100   9901    991  INT64\n"
-        "-------------------------------------------------\n"
+        "of grblas.Matrix         100   9901    991  INT64  hypercsr\n"
+        "-----------------------------------------------------------\n"
         "      row  col  val\n"
         "0     100   10    0\n"
         "1     200   20    0\n"
@@ -4054,9 +4133,9 @@ def test_sparse_matrix_repr():
     A2 = A[:2000, :].new(name="A2")
     repr_printer(A2, "A2")
     assert repr(A2) == (
-        '"A2"           nvals  nrows  ncols  dtype\n'
-        "grblas.Matrix     20   2000    991  INT64\n"
-        "-----------------------------------------\n"
+        '"A2"           nvals  nrows  ncols  dtype    format\n'
+        "grblas.Matrix     20   2000    991  INT64  hypercsr\n"
+        "---------------------------------------------------\n"
         "     row  col  val\n"
         "0      0    0    0\n"
         "1    100   10    1\n"
@@ -4081,10 +4160,10 @@ def test_sparse_matrix_repr():
     )
     repr_printer(A2.V, "A2.V")
     assert repr(A2.V) == (
-        '"A2.V"            nvals  nrows  ncols  dtype\n'
+        '"A2.V"            nvals  nrows  ncols  dtype    format\n'
         "ValueMask       \n"
-        "of grblas.Matrix     20   2000    991  INT64\n"
-        "--------------------------------------------\n"
+        "of grblas.Matrix     20   2000    991  INT64  hypercsr\n"
+        "------------------------------------------------------\n"
         "     row  col  val\n"
         "0    100   10    1\n"
         "1    200   20    1\n"
@@ -4126,18 +4205,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4179,18 +4260,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4248,18 +4331,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4301,18 +4386,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4373,7 +4460,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -4381,12 +4468,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4428,18 +4517,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4500,18 +4591,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4553,7 +4646,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub>.T</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub>.T</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.TransposedMatrix</pre></td>\n'
@@ -4561,12 +4654,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>1</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapc</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4634,7 +4729,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -4642,12 +4737,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4689,7 +4786,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub>.T</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub>.T</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.TransposedMatrix</pre></td>\n'
@@ -4697,12 +4794,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapc</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4762,7 +4861,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -4770,12 +4869,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4817,7 +4918,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -4825,12 +4926,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4888,7 +4991,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -4896,12 +4999,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -4943,7 +5048,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -4951,12 +5056,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>1</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5022,7 +5129,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub>.T</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub>.T</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.TransposedMatrix</pre></td>\n'
@@ -5030,12 +5137,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>1</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapc</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5085,7 +5194,7 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub>.T</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>B<sub>1</sub>.T</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.TransposedMatrix</pre></td>\n'
@@ -5093,12 +5202,14 @@ def test_infix_expr_repr_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapc</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5154,18 +5265,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5207,18 +5320,20 @@ def test_infix_expr_repr_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5355,18 +5470,20 @@ def test_inner_outer_repr_html(v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5408,18 +5525,20 @@ def test_inner_outer_repr_html(v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5477,18 +5596,20 @@ def test_inner_outer_repr_html(v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5530,18 +5651,20 @@ def test_inner_outer_repr_html(v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v</tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>5</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5626,7 +5749,7 @@ def test_autocompute_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -5634,12 +5757,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5681,7 +5806,7 @@ def test_autocompute_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -5689,12 +5814,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5755,7 +5882,7 @@ def test_autocompute_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -5763,12 +5890,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5810,7 +5939,7 @@ def test_autocompute_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>A<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -5818,12 +5947,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5873,12 +6004,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -5942,15 +6075,17 @@ def test_autocompute_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>0</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>0</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n" + "    <td>36028797018963968</td>\n" * 2 + "    <td>INT64</td>\n"
+        "    <td>full</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6066,18 +6201,20 @@ def test_autocompute_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>1</td>\n"
         "    <td>36028797018963968</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>sparse</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6201,11 +6338,13 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>1</td>\n"
         "    <td>36028797018963968</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>sparse</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6339,15 +6478,17 @@ def test_autocompute_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>0</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>0</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n" + "    <td>36028797018963968</td>\n" * 2 + "    <td>INT64</td>\n"
+        "    <td>full</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6463,18 +6604,20 @@ def test_autocompute_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>1</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>1</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>1</td>\n"
         "    <td>36028797018963968</td>\n"
         "    <td>INT64</td>\n"
+        "    <td>sparse</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6610,15 +6753,17 @@ def test_autocompute_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>6</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>6</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n" + "    <td>36028797018963968</td>\n" * 2 + "    <td>BOOL</td>\n"
+        "    <td>full</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6734,18 +6879,20 @@ def test_autocompute_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>7</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>v<sub>7</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Vector</pre></td>\n'
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>1</td>\n"
         "    <td>36028797018963968</td>\n"
         "    <td>BOOL</td>\n"
+        "    <td>sparse</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6881,7 +7028,7 @@ def test_autocompute_html(A, B, v):
         "</div>\n"
         '</summary><blockquote class="gb-expr-blockquote"><div>'
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>M<sub>2</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>M<sub>2</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -6889,12 +7036,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>BOOL</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6936,7 +7085,7 @@ def test_autocompute_html(A, B, v):
         "</table>\n"
         "</div></details></div><div>"
         f"{CSS_STYLE}"
-        '<details open class="gb-arg-details"><summary class="gb-arg-summary"><tt>M<sub>2</sub></tt><div>\n'
+        '<details class="gb-arg-details"><summary class="gb-arg-summary"><tt>M<sub>2</sub></tt><div>\n'
         '<table class="gb-info-table">\n'
         "  <tr>\n"
         '    <td rowspan="2" class="gb-info-name-cell"><pre>grblas.Matrix</pre></td>\n'
@@ -6944,12 +7093,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>BOOL</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6999,12 +7150,14 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>3</td>\n"
         "    <td>1</td>\n"
         "    <td>5</td>\n"
         "    <td>BOOL</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -7053,9 +7206,9 @@ def test_display_nan():
     v = Vector.from_values([0, 1], [1.0, np.nan], size=3, name="v")
     repr_printer(v, "v")
     assert repr(v) == (
-        '"v"            nvals  size  dtype\n'
-        "grblas.Vector      2     3   FP64\n"
-        "---------------------------------\n"
+        '"v"            nvals  size  dtype  format\n'
+        "grblas.Vector      2     3   FP64  bitmap\n"
+        "-----------------------------------------\n"
         "    0    1 2\n"
         "  1.0  nan  "
     )
@@ -7070,11 +7223,13 @@ def test_display_nan():
         "    <td><pre>nvals</pre></td>\n"
         "    <td><pre>size</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n"
         "    <td>2</td>\n"
         "    <td>3</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmap</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -7115,9 +7270,9 @@ def test_display_nan():
     A = Matrix.from_values([0, 0], [0, 1], [1.0, np.nan], ncols=3, nrows=2, name="A")
     repr_printer(A, "A")
     assert repr(A) == (
-        '"A"            nvals  nrows  ncols  dtype\n'
-        "grblas.Matrix      2      2      3   FP64\n"
-        "-----------------------------------------\n"
+        '"A"            nvals  nrows  ncols  dtype   format\n'
+        "grblas.Matrix      2      2      3   FP64  bitmapr\n"
+        "--------------------------------------------------\n"
         "     0    1 2\n"
         "0  1.0  nan  \n"
         "1            "
@@ -7134,9 +7289,11 @@ def test_display_nan():
         "    <td><pre>nrows</pre></td>\n"
         "    <td><pre>ncols</pre></td>\n"
         "    <td><pre>dtype</pre></td>\n"
+        "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n" + "    <td>2</td>\n" * 2 + "    <td>3</td>\n"
         "    <td>FP64</td>\n"
+        "    <td>bitmapr</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -7184,9 +7341,9 @@ def test_large_iso():
     A[:, :] << 1
     repr_printer(A, "A")
     assert repr(A) == (
-        '"M_0"                        nvals                nrows                ncols  dtype\n'
-        "grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64\n"
-        "-----------------------------------------------------------------------------------\n"
+        '"M_0"                        nvals                nrows                ncols  dtype  format\n'
+        "grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64   fullr\n"
+        "-------------------------------------------------------------------------------------------\n"
         "                    0                    ... 1152921504606846975\n"
         "0                                     1  ...                   1\n"
         "1                                     1  ...                   1\n"
@@ -7202,9 +7359,9 @@ def test_large_iso():
     )
     repr_printer(A.T, "A.T")
     assert repr(A.T) == (
-        '"M_0.T"                                nvals                nrows                ncols  dtype\n'
-        "grblas.TransposedMatrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64\n"
-        "---------------------------------------------------------------------------------------------\n"
+        '"M_0.T"                                nvals                nrows                ncols  dtype  format\n'
+        "grblas.TransposedMatrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64   fullc\n"
+        "-----------------------------------------------------------------------------------------------------\n"
         "                    0                    ... 1152921504606846975\n"
         "0                                     1  ...                   1\n"
         "1                                     1  ...                   1\n"
@@ -7220,10 +7377,10 @@ def test_large_iso():
     )
     repr_printer(A.S, "A.S")
     assert repr(A.S) == (
-        '"M_0.S"                         nvals                nrows                ncols  dtype\n'
+        '"M_0.S"                         nvals                nrows                ncols  dtype  format\n'
         "StructuralMask  \n"
-        "of grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64\n"
-        "--------------------------------------------------------------------------------------\n"
+        "of grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64   fullr\n"
+        "----------------------------------------------------------------------------------------------\n"
         "                    0                    ... 1152921504606846975\n"
         "0                                     1  ...                   1\n"
         "1                                     1  ...                   1\n"
@@ -7241,18 +7398,18 @@ def test_large_iso():
     v[:] = 1
     repr_printer(v, "v")
     assert repr(v) == (
-        '"v_0"                        nvals                 size  dtype\n'
-        "grblas.Vector  1152921504606846976  1152921504606846976  INT64\n"
-        "--------------------------------------------------------------\n"
+        '"v_0"                        nvals                 size  dtype  format\n'
+        "grblas.Vector  1152921504606846976  1152921504606846976  INT64    full\n"
+        "----------------------------------------------------------------------\n"
         " 0                    ... 1152921504606846975\n"
         "                   1  ...                   1"
     )
     repr_printer(v.S, "v.S")
     assert repr(v.S) == (
-        '"v_0.S"                         nvals                 size  dtype\n'
+        '"v_0.S"                         nvals                 size  dtype  format\n'
         "StructuralMask  \n"
-        "of grblas.Vector  1152921504606846976  1152921504606846976  INT64\n"
-        "-----------------------------------------------------------------\n"
+        "of grblas.Vector  1152921504606846976  1152921504606846976  INT64    full\n"
+        "-------------------------------------------------------------------------\n"
         " 0                    ... 1152921504606846975\n"
         "                   1  ...                   1"
     )

--- a/grblas/tests/test_formatting.py
+++ b/grblas/tests/test_formatting.py
@@ -5762,9 +5762,9 @@ def test_autocompute(A, B, v):
         "grblas.VectorExpression                                   size  dtype\n"
         "v_0.ewise_mult(v_1, op=binary.times[INT64])  36028797018963968  INT64\n"
         "\n"
-        '"Result"       nvals               size  dtype  format\n'
-        "grblas.Vector      1  36028797018963968  INT64  sparse\n"
-        "------------------------------------------------------\n"
+        '"Result"       nvals               size  dtype        format\n'
+        "grblas.Vector      1  36028797018963968  INT64  sparse (iso)\n"
+        "------------------------------------------------------------\n"
         " 0                 1                  ... 36028797018963966 36028797018963967\n"
         "                 2                    ...                                    \n"
         "\n"
@@ -6167,7 +6167,7 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n" + "    <td>36028797018963968</td>\n" * 2 + "    <td>INT64</td>\n"
-        "    <td>full</td>\n"
+        "    <td>full (iso)</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6296,7 +6296,7 @@ def test_autocompute_html(A, B, v):
         "    <td>1</td>\n"
         "    <td>36028797018963968</td>\n"
         "    <td>INT64</td>\n"
-        "    <td>sparse</td>\n"
+        "    <td>sparse (iso)</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6426,7 +6426,7 @@ def test_autocompute_html(A, B, v):
         "    <td>1</td>\n"
         "    <td>36028797018963968</td>\n"
         "    <td>INT64</td>\n"
-        "    <td>sparse</td>\n"
+        "    <td>sparse (iso)</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6570,7 +6570,7 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n" + "    <td>36028797018963968</td>\n" * 2 + "    <td>INT64</td>\n"
-        "    <td>full</td>\n"
+        "    <td>full (iso)</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6699,7 +6699,7 @@ def test_autocompute_html(A, B, v):
         "    <td>1</td>\n"
         "    <td>36028797018963968</td>\n"
         "    <td>INT64</td>\n"
-        "    <td>sparse</td>\n"
+        "    <td>sparse (iso)</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -6845,7 +6845,7 @@ def test_autocompute_html(A, B, v):
         "    <td><pre>format</pre></td>\n"
         "  </tr>\n"
         "  <tr>\n" + "    <td>36028797018963968</td>\n" * 2 + "    <td>BOOL</td>\n"
-        "    <td>full</td>\n"
+        "    <td>full (iso)</td>\n"
         "  </tr>\n"
         "</table>\n"
         "</div>\n"
@@ -7423,9 +7423,9 @@ def test_large_iso():
     A[:, :] << 1
     repr_printer(A, "A")
     assert repr(A) == (
-        '"M_0"                        nvals                nrows                ncols  dtype  format\n'
-        "grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64   fullr\n"
-        "-------------------------------------------------------------------------------------------\n"
+        '"M_0"                        nvals                nrows                ncols  dtype       format\n'
+        "grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64  fullr (iso)\n"
+        "------------------------------------------------------------------------------------------------\n"
         "                    0                    ... 1152921504606846975\n"
         "0                                     1  ...                   1\n"
         "1                                     1  ...                   1\n"
@@ -7441,9 +7441,9 @@ def test_large_iso():
     )
     repr_printer(A.T, "A.T")
     assert repr(A.T) == (
-        '"M_0.T"                                nvals                nrows                ncols  dtype  format\n'
-        "grblas.TransposedMatrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64   fullc\n"
-        "-----------------------------------------------------------------------------------------------------\n"
+        '"M_0.T"                                nvals                nrows                ncols  dtype       format\n'
+        "grblas.TransposedMatrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64  fullc (iso)\n"
+        "----------------------------------------------------------------------------------------------------------\n"
         "                    0                    ... 1152921504606846975\n"
         "0                                     1  ...                   1\n"
         "1                                     1  ...                   1\n"
@@ -7459,10 +7459,10 @@ def test_large_iso():
     )
     repr_printer(A.S, "A.S")
     assert repr(A.S) == (
-        '"M_0.S"                         nvals                nrows                ncols  dtype  format\n'
+        '"M_0.S"                         nvals                nrows                ncols  dtype       format\n'
         "StructuralMask  \n"
-        "of grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64   fullr\n"
-        "----------------------------------------------------------------------------------------------\n"
+        "of grblas.Matrix  9223372036854775807  1152921504606846976  1152921504606846976  INT64  fullr (iso)\n"
+        "---------------------------------------------------------------------------------------------------\n"
         "                    0                    ... 1152921504606846975\n"
         "0                                     1  ...                   1\n"
         "1                                     1  ...                   1\n"
@@ -7480,18 +7480,18 @@ def test_large_iso():
     v[:] = 1
     repr_printer(v, "v")
     assert repr(v) == (
-        '"v_0"                        nvals                 size  dtype  format\n'
-        "grblas.Vector  1152921504606846976  1152921504606846976  INT64    full\n"
-        "----------------------------------------------------------------------\n"
+        '"v_0"                        nvals                 size  dtype      format\n'
+        "grblas.Vector  1152921504606846976  1152921504606846976  INT64  full (iso)\n"
+        "--------------------------------------------------------------------------\n"
         " 0                    ... 1152921504606846975\n"
         "                   1  ...                   1"
     )
     repr_printer(v.S, "v.S")
     assert repr(v.S) == (
-        '"v_0.S"                         nvals                 size  dtype  format\n'
+        '"v_0.S"                         nvals                 size  dtype      format\n'
         "StructuralMask  \n"
-        "of grblas.Vector  1152921504606846976  1152921504606846976  INT64    full\n"
-        "-------------------------------------------------------------------------\n"
+        "of grblas.Vector  1152921504606846976  1152921504606846976  INT64  full (iso)\n"
+        "-----------------------------------------------------------------------------\n"
         " 0                    ... 1152921504606846975\n"
         "                   1  ...                   1"
     )

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -54,12 +54,12 @@ class Vector(BaseType):
         with skip_record:
             return format_vector(self, mask=mask)
 
-    def _repr_html_(self, mask=None):
+    def _repr_html_(self, mask=None, collapse=False):
         from .formatting import format_vector_html
         from .recorder import skip_record
 
         with skip_record:
-            return format_vector_html(self, mask=mask)
+            return format_vector_html(self, mask=mask, collapse=collapse)
 
     def __reduce__(self):
         # SS, SuiteSparse-specific: export


### PR DESCRIPTION
Although format such as `csr` is SuiteSparse-specific, this seems useful to show.Hopefully it's not too much of a burden to keep the tests up to date (since SuiteSparse is free to change the underlying formats).

Other changes:
- expressions now show autocomputed results in `__repr__` (not just `_repr_html_`)
- expressions `_repr_html_` collapse the input arguments