### PR TITLE
Import grblas faster by delaying creation of new ops.

### DIFF
--- a/grblas/binary/__init__.py
+++ b/grblas/binary/__init__.py
@@ -1,7 +1,29 @@
 # All items are dynamically added by classes in operator.py
 # This module acts as a container of BinaryOp instances
-from grblas import operator
-
-from . import numpy  # noqa
+_delayed = {}
+_delayed_commutes_to = {
+    "absfirst": "abssecond",
+    "abssecond": "absfirst",
+    "floordiv": "rfloordiv",
+    "rfloordiv": "floordiv",
+}
+from grblas import operator  # noqa isort:skip
+from . import numpy  # noqa isort:skip
 
 del operator
+
+
+def __getattr__(key):
+    if key in _delayed:
+        func, kwargs = _delayed.pop(key)
+        rv = func(**kwargs)
+        globals()[key] = rv
+        if key in _delayed_commutes_to:
+            other_key = _delayed_commutes_to[key]
+            if other_key in globals():
+                other = globals()[other_key]
+            else:
+                other = __getattr__(other_key)
+            rv.commutes_to = other
+        return rv
+    raise AttributeError(f"module {__name__!r} has no attribute {key!r}")

--- a/grblas/binary/numpy.py
+++ b/grblas/binary/numpy.py
@@ -11,6 +11,7 @@ from .. import binary as _binary
 from .. import config as _config
 from .. import operator as _operator
 
+_delayed = {}
 _binary_names = {
     # Math operations
     "add",
@@ -123,10 +124,15 @@ _commutes_to = {
 
 
 def __dir__():
-    return __all__
+    return __all__ + list(_delayed)
 
 
 def __getattr__(name):
+    if name in _delayed:
+        func, kwargs = _delayed.pop(name)
+        rv = func(**kwargs)
+        globals()[name] = rv
+        return rv
     if name not in _binary_names:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     if _config.get("mapnumpy") and name in _numpy_to_graphblas:

--- a/grblas/monoid/__init__.py
+++ b/grblas/monoid/__init__.py
@@ -1,7 +1,16 @@
 # All items are dynamically added by classes in operator.py
 # This module acts as a container of Monoid instances
-from grblas import operator
-
-from . import numpy  # noqa
+_delayed = {}
+from grblas import operator  # noqa isort:skip
+from . import numpy  # noqa isort:skip
 
 del operator
+
+
+def __getattr__(key):
+    if key in _delayed:
+        func, kwargs = _delayed.pop(key)
+        rv = func(**kwargs)
+        globals()[key] = rv
+        return rv
+    raise AttributeError(f"module {__name__!r} has no attribute {key!r}")

--- a/grblas/monoid/__init__.py
+++ b/grblas/monoid/__init__.py
@@ -10,6 +10,10 @@ del operator
 def __getattr__(key):
     if key in _delayed:
         func, kwargs = _delayed.pop(key)
+        if type(kwargs["binaryop"]) is str:
+            from ..binary import from_string
+
+            kwargs["binaryop"] = from_string(kwargs["binaryop"])
         rv = func(**kwargs)
         globals()[key] = rv
         return rv

--- a/grblas/monoid/numpy.py
+++ b/grblas/monoid/numpy.py
@@ -122,6 +122,10 @@ def __dir__():
 def __getattr__(name):
     if name in _delayed:
         func, kwargs = _delayed.pop(name)
+        if type(kwargs["binaryop"]) is str:
+            from ..binary import from_string
+
+            kwargs["binaryop"] = from_string(kwargs["binaryop"])
         rv = func(**kwargs)
         globals()[name] = rv
         return rv

--- a/grblas/monoid/numpy.py
+++ b/grblas/monoid/numpy.py
@@ -13,6 +13,7 @@ from .. import monoid as _monoid
 from .. import operator as _operator
 from ..dtypes import _supports_complex
 
+_delayed = {}
 _complex_dtypes = {"FC32", "FC64"}
 _float_dtypes = {"FP32", "FP64"}
 _int_dtypes = {"INT8", "UINT8", "INT16", "UINT16", "INT32", "UINT32", "INT64", "UINT64"}
@@ -115,10 +116,15 @@ _numpy_to_graphblas = {
 
 
 def __dir__():
-    return __all__
+    return __all__ + list(_delayed)
 
 
 def __getattr__(name):
+    if name in _delayed:
+        func, kwargs = _delayed.pop(name)
+        rv = func(**kwargs)
+        globals()[name] = rv
+        return rv
     if name not in _monoid_identities:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     if _config.get("mapnumpy") and name in _numpy_to_graphblas:

--- a/grblas/op/__init__.py
+++ b/grblas/op/__init__.py
@@ -1,7 +1,16 @@
 # All items are dynamically added by classes in operator.py
 # This module acts as a container of all UnaryOp, BinaryOp, and Semiring instances
-from grblas import operator
-
-from . import numpy  # noqa
+_delayed = {}
+from grblas import operator  # noqa isort:skip
+from . import numpy  # noqa isort:skip
 
 del operator
+
+
+def __getattr__(key):
+    if key in _delayed:
+        module = _delayed.pop(key)
+        rv = getattr(module, key)
+        globals()[key] = rv
+        return rv
+    raise AttributeError(f"module {__name__!r} has no attribute {key!r}")

--- a/grblas/op/numpy.py
+++ b/grblas/op/numpy.py
@@ -2,6 +2,7 @@ from ..binary import numpy as _np_binary
 from ..semiring import numpy as _np_semiring
 from ..unary import numpy as _np_unary
 
+_delayed = {}
 _op_to_mod = dict.fromkeys(_np_unary.__all__, _np_unary)
 _op_to_mod.update(dict.fromkeys(_np_binary.__all__, _np_binary))
 _op_to_mod.update(dict.fromkeys(_np_semiring.__all__, _np_semiring))
@@ -9,10 +10,15 @@ __all__ = list(_op_to_mod)
 
 
 def __dir__():
-    return __all__
+    return __all__ + list(_delayed)
 
 
 def __getattr__(name):
+    if name in _delayed:
+        module = _delayed.pop(name)
+        rv = getattr(module, name)
+        globals()[name] = rv
+        return rv
     try:
         rv = getattr(_op_to_mod[name], name)
     except KeyError:

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -1699,7 +1699,7 @@ try:
     BinaryOp._initialize()
     Monoid._initialize()
     Semiring._initialize()
-except Exception:
+except Exception:  # pragma: no cover
     # Exceptions here can often get ignored by Python
     import traceback
 
@@ -1774,7 +1774,7 @@ def _from_string(string, module, mapping, example):
         cur = module
         for path in paths:
             cur = getattr(cur, path, None)
-            if not isinstance(module, (OpPath, ModuleType)):
+            if not isinstance(cur, (OpPath, ModuleType)):
                 cur = None
                 break
         op = getattr(cur, attr, None)
@@ -1827,7 +1827,7 @@ def op_from_string(string):
             return func(string)
         except Exception:
             pass
-    unary_from_string(string)
+    raise ValueError(f"Unknown op string: {string!r}.  Example usage: 'abs[int]'")
 
 
 unary.from_string = unary_from_string

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -1670,11 +1670,18 @@ def get_semiring(monoid, binaryop, name=None):
             name = canonical_name
 
         module, funcname = Semiring._remove_nesting(canonical_name, strict=False)
-        # TODO: check module._delayed?
-        rv = module.__dict__.get(funcname)
+        rv = (
+            getattr(module, funcname)
+            if funcname in module.__dict__ or funcname in module._delayed
+            else None
+        )
         if rv is None and name != canonical_name:
             module, funcname = Semiring._remove_nesting(name, strict=False)
-            rv = module.__dict__.get(funcname)
+            rv = (
+                getattr(module, funcname)
+                if funcname in module.__dict__ or funcname in module._delayed
+                else None
+            )
         if rv is None:
             rv = Semiring.register_new(canonical_name, monoid, binaryop)
         elif rv.monoid is not monoid or rv.binaryop is not binaryop:  # pragma: no cover

--- a/grblas/semiring/__init__.py
+++ b/grblas/semiring/__init__.py
@@ -1,7 +1,24 @@
 # All items are dynamically added by classes in operator.py
 # This module acts as a container of Semiring instances
-from grblas import operator
-
-from . import numpy  # noqa
+_delayed = {}
+from grblas import operator  # noqa isort:skip
+from . import numpy  # noqa isort:skip
 
 del operator
+
+
+def __getattr__(key):
+    if key in _delayed:
+        func, kwargs = _delayed.pop(key)
+        if type(kwargs["binaryop"]) is str:
+            from ..binary import from_string
+
+            kwargs["binaryop"] = from_string(kwargs["binaryop"])
+        if type(kwargs["monoid"]) is str:
+            from ..monoid import from_string
+
+            kwargs["monoid"] = from_string(kwargs["monoid"])
+        rv = func(**kwargs)
+        globals()[key] = rv
+        return rv
+    raise AttributeError(f"module {__name__!r} has no attribute {key!r}")

--- a/grblas/semiring/numpy.py
+++ b/grblas/semiring/numpy.py
@@ -13,6 +13,7 @@ from .. import operator as _operator
 from ..binary.numpy import _binary_names
 from ..monoid.numpy import _monoid_identities
 
+_delayed = {}
 _semiring_names = {
     f"{monoid_name}_{binary_name}"
     for monoid_name, binary_name in _itertools.product(_monoid_identities, _binary_names)
@@ -86,10 +87,15 @@ __all__ = list(_semiring_names)
 
 
 def __dir__():
-    return __all__
+    return __all__ + list(_delayed)
 
 
 def __getattr__(name):
+    if name in _delayed:
+        func, kwargs = _delayed.pop(name)
+        rv = func(**kwargs)
+        globals()[name] = rv
+        return rv
     if name not in _semiring_names:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     words = name.split("_")

--- a/grblas/semiring/numpy.py
+++ b/grblas/semiring/numpy.py
@@ -93,6 +93,14 @@ def __dir__():
 def __getattr__(name):
     if name in _delayed:
         func, kwargs = _delayed.pop(name)
+        if type(kwargs["binaryop"]) is str:
+            from ..binary import from_string
+
+            kwargs["binaryop"] = from_string(kwargs["binaryop"])
+        if type(kwargs["monoid"]) is str:
+            from ..monoid import from_string
+
+            kwargs["monoid"] = from_string(kwargs["monoid"])
         rv = func(**kwargs)
         globals()[name] = rv
         return rv

--- a/grblas/tests/conftest.py
+++ b/grblas/tests/conftest.py
@@ -5,7 +5,7 @@ import itertools
 import numpy as np
 import pytest
 
-import grblas
+import grblas as gb
 
 
 def pytest_configure(config):
@@ -16,15 +16,15 @@ def pytest_configure(config):
     if mapnumpy is None:  # pragma: no branch
         mapnumpy = np.random.rand() < 0.5  # heh
 
-    grblas.config.set(autocompute=False, mapnumpy=mapnumpy)
+    gb.config.set(autocompute=False, mapnumpy=mapnumpy)
 
-    grblas.init(backend, blocking=blocking)
+    gb.init(backend, blocking=blocking)
     print(
         f'Running tests with "{backend}" backend, blocking={blocking}, '
         f"record={record}, mapnumpy={mapnumpy}"
     )
     if record:
-        rec = grblas.Recorder()
+        rec = gb.Recorder()
         rec.start()
 
         def save_records():
@@ -33,6 +33,9 @@ def pytest_configure(config):
 
         # I'm sure there's a `pytest` way to do this...
         atexit.register(save_records)
+    for mod in [gb.unary, gb.binary, gb.monoid, gb.semiring, gb.op]:
+        for name in list(mod._delayed):
+            getattr(mod, name)
 
 
 def pytest_runtest_setup(item):
@@ -43,15 +46,15 @@ def pytest_runtest_setup(item):
 @pytest.fixture(autouse=True, scope="function")
 def reset_name_counters():
     """Reset automatic names for each test for easier comparison of record.txt"""
-    grblas.Matrix._name_counter = itertools.count()
-    grblas.Vector._name_counter = itertools.count()
-    grblas.Scalar._name_counter = itertools.count()
+    gb.Matrix._name_counter = itertools.count()
+    gb.Vector._name_counter = itertools.count()
+    gb.Scalar._name_counter = itertools.count()
 
 
 def autocompute(func):
     @functools.wraps(func)
     def inner(*args, **kwargs):
-        with grblas.config.set(autocompute=True):
+        with gb.config.set(autocompute=True):
             return func(*args, **kwargs)
 
     return inner

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -653,11 +653,11 @@ def test_op_namespace():
         for key, val in vars(semiring).items()
         if isinstance(val, (operator.OpBase, operator.ParameterizedUdf))
     }
-    assert len(unarynames - opnames) == 0
-    assert len(binarynames - opnames) == 0
-    assert len(monoidnames - opnames) == 0
-    assert len(semiringnames - opnames) == 0
-    assert len(opnames - (unarynames | binarynames | monoidnames | semiringnames)) == 0
+    assert not unarynames - opnames, unarynames - opnames
+    assert not binarynames - opnames, binarynames - opnames
+    assert not monoidnames - opnames, monoidnames - opnames
+    assert not semiringnames - opnames, semiringnames - opnames
+    assert not opnames - (unarynames | binarynames | monoidnames | semiringnames)
 
 
 @pytest.mark.slow
@@ -770,8 +770,8 @@ def test_binaryop_superset_monoids():
     monoid_names = {x for x in dir(monoid) if not x.startswith("_")}
     binary_names = {x for x in dir(binary) if not x.startswith("_")}
     diff = monoid_names - binary_names
-    assert len(diff) == 0
-    assert len(set(dir(monoid.numpy)) - set(dir(binary.numpy))) == 0
+    assert not diff
+    assert not set(dir(monoid.numpy)) - set(dir(binary.numpy))
 
 
 def test_div_semirings():
@@ -909,6 +909,8 @@ def test_from_string():
     assert binary.from_string("+") is binary.plus
     assert binary.from_string("-[int]") is binary.minus[int]
     assert binary.from_string("true_divide") is binary.numpy.true_divide
+    assert binary.from_string("//") is binary.floordiv
+    assert binary.from_string("%") is binary.numpy.mod
     assert monoid.from_string("*[FP64]") is monoid.times["FP64"]
     assert semiring.from_string("min.plus") is semiring.min_plus
     assert semiring.from_string("min.+") is semiring.min_plus

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -967,6 +967,7 @@ def test_lazy_op():
     assert isinstance(monoid.numpy.lazy, Monoid)
     assert isinstance(binary.numpy.lazy, BinaryOp)
     Monoid.register_new("numpy.lazy2", binary.numpy.lazy, 0, lazy=True)
+    assert isinstance(operator.get_semiring(monoid.numpy.lazy2, binary.numpy.lazy), Semiring)
     assert isinstance(op.numpy.lazy2, Monoid)
     assert isinstance(monoid.numpy.lazy2, Monoid)
     Semiring.register_new("numpy.lazy", "numpy.lazy", "numpy.lazy", lazy=True)

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -629,9 +629,9 @@ def test_op_namespace():
     ):
         op.numpy.bad_attr
 
-    for key in list(op._delayed):
+    # Make sure all have been initialized so `vars` below works
+    for key in list(op._delayed):  # pragma: no cover
         getattr(op, key)
-
     opnames = {
         key
         for key, val in vars(op).items()
@@ -946,12 +946,14 @@ def test_from_string():
 
 def test_lazy_op():
     UnaryOp.register_new("lazy", lambda x: x, lazy=True)
+    assert isinstance(op.lazy, UnaryOp)
     assert isinstance(unary.lazy, UnaryOp)
     BinaryOp.register_new("lazy", lambda x, y: x + y, lazy=True)
     Monoid.register_new("lazy", "lazy", 0, lazy=True)
     assert isinstance(monoid.lazy, Monoid)
     assert isinstance(binary.lazy, BinaryOp)
     Monoid.register_new("lazy2", binary.lazy, 0, lazy=True)
+    assert isinstance(op.lazy2, Monoid)
     assert isinstance(monoid.lazy2, Monoid)
     Semiring.register_new("lazy", "lazy", "lazy", lazy=True)
     assert isinstance(semiring.lazy, Semiring)
@@ -965,6 +967,7 @@ def test_lazy_op():
     assert isinstance(monoid.numpy.lazy, Monoid)
     assert isinstance(binary.numpy.lazy, BinaryOp)
     Monoid.register_new("numpy.lazy2", binary.numpy.lazy, 0, lazy=True)
+    assert isinstance(op.numpy.lazy2, Monoid)
     assert isinstance(monoid.numpy.lazy2, Monoid)
     Semiring.register_new("numpy.lazy", "numpy.lazy", "numpy.lazy", lazy=True)
     assert isinstance(semiring.numpy.lazy, Semiring)

--- a/grblas/tests/test_operator_types.py
+++ b/grblas/tests/test_operator_types.py
@@ -143,6 +143,9 @@ for name, (ins, outs) in _SEMIRING2.items():
 IGNORE = {
     # Created by
     "plus_copysign",
+    "lazy",
+    "lazy2",
+    "lazy_lazy",
     # UDFs created during tests
     "is_positive",
     "plus_one",

--- a/grblas/unary/__init__.py
+++ b/grblas/unary/__init__.py
@@ -1,7 +1,16 @@
 # All items are dynamically added by classes in operator.py
 # This module acts as a container of UnaryOp instances
-from grblas import operator
-
-from . import numpy  # noqa
+_delayed = {}
+from grblas import operator  # noqa isort:skip
+from . import numpy  # noqa isort:skip
 
 del operator
+
+
+def __getattr__(key):
+    if key in _delayed:
+        func, kwargs = _delayed.pop(key)
+        rv = func(**kwargs)
+        globals()[key] = rv
+        return rv
+    raise AttributeError(f"module {__name__!r} has no attribute {key!r}")

--- a/grblas/unary/numpy.py
+++ b/grblas/unary/numpy.py
@@ -11,6 +11,7 @@ from .. import config as _config
 from .. import operator as _operator
 from .. import unary as _unary
 
+_delayed = {}
 _unary_names = {
     # Math operations
     "negative",
@@ -108,10 +109,15 @@ _numpy_to_graphblas = {
 
 
 def __dir__():
-    return __all__
+    return __all__ + list(_delayed)
 
 
 def __getattr__(name):
+    if name in _delayed:
+        func, kwargs = _delayed.pop(name)
+        rv = func(**kwargs)
+        globals()[name] = rv
+        return rv
     if name not in _unary_names:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     if _config.get("mapnumpy") and name in _numpy_to_graphblas:


### PR DESCRIPTION
Fixes #130.  CC @ParticularMiner

Now the import time of grblas is dominated by importing pandas, numba, and numpy.  For me, the import time is about 5x faster (hooray!).

This was a bit more complicated than I expected.  I'll give this another pass tomorrow.