### PR TITLE
Make `gb.ss.concat` work with vectors!

### DIFF
--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -193,15 +193,18 @@ def normalize_chunks(chunks, shape):
     if isinstance(chunks, (list, tuple)):
         pass
     elif isinstance(chunks, Number):
-        chunks = (chunks, chunks)
+        chunks = (chunks,) * len(shape)
     elif isinstance(chunks, np.ndarray):
         chunks = chunks.tolist()
     else:
         raise TypeError(
             f"chunks argument must be a list, tuple, or numpy array; got: {type(chunks)}"
         )
-    if len(chunks) != 2:
-        raise ValueError("chunks argument must be of length 2 (one for each dimension of a Matrix)")
+    if len(chunks) != len(shape):
+        typ = "Vector" if len(shape) == 1 else "Matrix"
+        raise ValueError(
+            f"chunks argument must be of length {len(shape)} (one for each dimension of a {typ})"
+        )
     chunksizes = []
     for size, chunk in zip(shape, chunks):
         if chunk is None:
@@ -507,6 +510,8 @@ class ss:
         Concatenate a 2D list of Matrix objects into the current Matrix.
         Any existing values in the current Matrix will be discarded.
         To concatenate into a new Matrix, use `grblas.ss.concat`.
+
+        Vectors may be used as `Nx1` Matrix objects.
 
         This performs the opposite operation as ``split``.
 

--- a/grblas/ss/_core.py
+++ b/grblas/ss/_core.py
@@ -74,11 +74,18 @@ def concat(tiles, dtype=None, *, name=None):
     Matrix.ss.concat
 
     """
-    tiles, m, n = _concat_mn(tiles)
-    if dtype is None:
-        dtype = tiles[0][0].dtype
-    nrows = sum(row_tiles[0]._nrows for row_tiles in tiles)
-    ncols = sum(tile._ncols for tile in tiles[0])
-    rv = Matrix.new(dtype, nrows=nrows, ncols=ncols, name=name)
-    rv.ss._concat(tiles, m, n)
+    tiles, m, n, is_matrix = _concat_mn(tiles)
+    if is_matrix:
+        if dtype is None:
+            dtype = tiles[0][0].dtype
+        nrows = sum(row_tiles[0]._nrows for row_tiles in tiles)
+        ncols = sum(tile._ncols for tile in tiles[0])
+        rv = Matrix.new(dtype, nrows=nrows, ncols=ncols, name=name)
+        rv.ss._concat(tiles, m, n)
+    else:
+        if dtype is None:
+            dtype = tiles[0].dtype
+        size = sum(tile._nrows for tile in tiles)
+        rv = Vector.new(dtype, size=size, name=name)
+        rv.ss._concat(tiles, m)
     return rv

--- a/grblas/ss/_core.py
+++ b/grblas/ss/_core.py
@@ -63,8 +63,11 @@ def concat(tiles, dtype=None, *, name=None):
     """
     GxB_Matrix_concat
 
-    Concatenate a 2D list of Matrix objects into a new Matrix.
-    To concatenate into an existing Matrix, use ``Matrix.ss.concat``.
+    Concatenate a 2D list of Matrix objects into a new Matrix, or a 1D list of
+    Vector objects into a new Vector.  To concatenate into existing objects,
+    use ``Matrix.ss.concat`` or `Vector.ss.concat`.
+
+    Vectors may be used as `Nx1` Matrix objects when creating a new Matrix.
 
     This performs the opposite operation as ``split``.
 
@@ -72,6 +75,8 @@ def concat(tiles, dtype=None, *, name=None):
     --------
     Matrix.ss.split
     Matrix.ss.concat
+    Vector.ss.split
+    Vector.ss.concat
 
     """
     tiles, m, n, is_matrix = _concat_mn(tiles)

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -2361,7 +2361,7 @@ def test_split(A):
         A.ss.split([[5, 5], 3])
 
 
-def test_concat(A):
+def test_concat(A, v):
     B1 = grblas.ss.concat([[A, A]], dtype=float)
     assert B1.dtype == "FP64"
     expected = Matrix.new(A.dtype, nrows=A.nrows, ncols=2 * A.ncols)
@@ -2393,6 +2393,30 @@ def test_concat(A):
         grblas.ss.concat([[]])
     with pytest.raises(ValueError, match="tiles must all be the same length"):
         grblas.ss.concat([[A], [A, A]])
+
+    # Treat vectors like Nx1 matrices
+    B3 = grblas.ss.concat([[v, v]])
+    expected = Matrix.new(v.dtype, nrows=v.size, ncols=2)
+    expected[:, 0] = v
+    expected[:, 1] = v
+    assert B3.isequal(expected)
+
+    B4 = grblas.ss.concat([[v], [v]])
+    expected = Matrix.new(v.dtype, nrows=2 * v.size, ncols=1)
+    expected[: v.size, 0] = v
+    expected[v.size :, 0] = v
+    assert B4.isequal(expected)
+
+    B5 = grblas.ss.concat([[A, v]])
+    expected = Matrix.new(v.dtype, nrows=v.size, ncols=A.ncols + 1)
+    expected[:, : A.ncols] = A
+    expected[:, A.ncols] = v
+    assert B5.isequal(expected)
+
+    with pytest.raises(TypeError, match=""):
+        grblas.ss.concat([v, [v]])
+    with pytest.raises(TypeError):
+        grblas.ss.concat([[v], v])
 
 
 def test_nbytes(A):
@@ -2516,6 +2540,7 @@ def test_expr_is_like_matrix(A):
         "_deserialize",
         "_extract_element",
         "_name_counter",
+        "_parent",
         "_prep_for_assign",
         "_prep_for_extract",
         "_update",

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1267,6 +1267,7 @@ def test_expr_is_like_vector(v):
         "__delitem__",
         "__lshift__",
         "__setitem__",
+        "_as_matrix",
         "_assign_element",
         "_delete_element",
         "_deserialize",
@@ -1391,3 +1392,16 @@ def test_slice():
     w = v[4:-3:-1].new()
     expected = Vector.from_values(np.arange(2), np.arange(5)[4:-3:-1])
     assert w.isequal(expected)
+
+
+def test_concat(v):
+    expected = Vector.new(v.dtype, size=2 * v.size)
+    expected[: v.size] = v
+    expected[v.size :] = v
+    w1 = grblas.ss.concat([v, v])
+    assert w1.isequal(expected)
+    w2 = Vector.new(v.dtype, size=2 * v.size)
+    w2.ss.concat([v, v])
+    assert w2.isequal(expected)
+    with pytest.raises(TypeError):
+        w2.ss.concat([[v, v]])

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1405,3 +1405,16 @@ def test_concat(v):
     assert w2.isequal(expected)
     with pytest.raises(TypeError):
         w2.ss.concat([[v, v]])
+
+
+def test_split(v):
+    w1, w2 = v.ss.split(4)
+    expected1 = Vector.from_values([1, 3], 1)
+    expected2 = Vector.from_values([0, 2], [2, 0])
+    assert w1.isequal(expected1)
+    assert w2.isequal(expected2)
+    x1, x2 = v.ss.split([4, 3], name="split")
+    assert x1.isequal(expected1)
+    assert x2.isequal(expected2)
+    assert x1.name == "split_0"
+    assert x2.name == "split_1"

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -47,6 +47,24 @@ class Vector(BaseType):
             # it's difficult/dangerous to record the call, b/c `self.name` may not exist
             check_status(lib.GrB_Vector_free(gb_obj), self)
 
+    def _as_matrix(self):
+        """Cast this Vector to a Matrix (such as a column vector).
+
+        This is SuiteSparse-specific and may change in the future.
+        This does not copy the vector.
+        """
+        from .matrix import Matrix
+
+        rv = Matrix(
+            ffi.cast("GrB_Matrix*", self.gb_obj),
+            self.dtype,
+            parent=self,
+            name=f"(GrB_Matrix){self.name}",
+        )
+        rv._nrows = self._size
+        rv._ncols = 1
+        return rv
+
     def __repr__(self, mask=None):
         from .formatting import format_vector
         from .recorder import skip_record
@@ -543,7 +561,7 @@ class Vector(BaseType):
         expr = ScalarExpression(
             method_name,
             "GrB_vxm",
-            [self, _VectorAsMatrix(other)],
+            [self, other._as_matrix()],
             op=op,
         )
         if self._size != other._size:
@@ -570,7 +588,7 @@ class Vector(BaseType):
         expr = MatrixExpression(
             method_name,
             "GrB_mxm",
-            [_VectorAsMatrix(self), _VectorAsMatrix(other)],
+            [self._as_matrix(), other._as_matrix()],
             op=op,
             nrows=self._size,
             ncols=other._size,

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -852,31 +852,6 @@ class VectorExpression(BaseExpression):
     __ixor__ = _automethods.__ixor__
 
 
-class _VectorAsMatrix:
-    __slots__ = "vector"
-
-    def __init__(self, vector):
-        self.vector = vector
-
-    @property
-    def _carg(self):
-        # SS, SuiteSparse-specific: casting Vector to Matrix
-        return ffi.cast("GrB_Matrix*", self.vector.gb_obj)[0]
-
-    @property
-    def name(self):
-        # Showing `(GrB_Matrix)` is good for the recorder, but not for the html repr
-        return f"(GrB_Matrix){self.vector.name}"
-
-    @property
-    def _name_html(self):
-        return self.vector._name_html
-
-    @property
-    def _repr_html_(self):
-        return self.vector._repr_html_
-
-
 utils._output_types[Vector] = Vector
 utils._output_types[VectorExpression] = Vector
 


### PR DESCRIPTION
When creating a Matrix, a Vector is handled as an Nx1 Matrix.

I still need to update the docstring for usage.
I would also like to add `v.ss.split` for Vectors.

For example:
```python
>>> gb.ss.concat([v, v])  # Vector, size=2*N
>>> gb.ss.concat([[v], [v]])  # Matrix, nrows=2*N, ncols=1
>>> gb.ss.concat([[v, v]])  # Matrix, nrows=N, ncols=2
```