### PR TITLE
Add `.ndim` attribute to objects

### DIFF
--- a/grblas/infix.py
+++ b/grblas/infix.py
@@ -40,6 +40,7 @@ def _ewise_mult_to_expr(self):
 
 class VectorInfixExpr(InfixExprBase):
     __slots__ = "_size"
+    ndim = 1
     output_type = VectorExpression
 
     def __init__(self, left, right):
@@ -105,8 +106,8 @@ class VectorInfixExpr(InfixExprBase):
 class VectorEwiseAddExpr(VectorInfixExpr):
     __slots__ = ()
     method_name = "ewise_add"
-    _infix = "|"
     _example_op = "plus"
+    _infix = "|"
 
     _to_expr = _ewise_add_to_expr
 
@@ -114,16 +115,16 @@ class VectorEwiseAddExpr(VectorInfixExpr):
 class VectorEwiseMultExpr(VectorInfixExpr):
     __slots__ = ()
     method_name = "ewise_mult"
-    _infix = "&"
     _example_op = "times"
+    _infix = "&"
 
     _to_expr = _ewise_mult_to_expr
 
 
 class VectorMatMulExpr(VectorInfixExpr):
     __slots__ = "method_name"
-    _infix = "@"
     _example_op = "plus_times"
+    _infix = "@"
 
     def __init__(self, left, right, *, method_name, size):
         InfixExprBase.__init__(self, left, right)
@@ -138,6 +139,7 @@ utils._output_types[VectorMatMulExpr] = Vector
 
 class MatrixInfixExpr(InfixExprBase):
     __slots__ = "_nrows", "_ncols"
+    ndim = 2
     output_type = MatrixExpression
     _is_transposed = False
 
@@ -214,8 +216,8 @@ class MatrixInfixExpr(InfixExprBase):
 class MatrixEwiseAddExpr(MatrixInfixExpr):
     __slots__ = ()
     method_name = "ewise_add"
-    _infix = "|"
     _example_op = "plus"
+    _infix = "|"
 
     _to_expr = _ewise_add_to_expr
 
@@ -223,8 +225,8 @@ class MatrixEwiseAddExpr(MatrixInfixExpr):
 class MatrixEwiseMultExpr(MatrixInfixExpr):
     __slots__ = ()
     method_name = "ewise_mult"
-    _infix = "&"
     _example_op = "times"
+    _infix = "&"
 
     _to_expr = _ewise_mult_to_expr
 
@@ -232,8 +234,8 @@ class MatrixEwiseMultExpr(MatrixInfixExpr):
 class MatrixMatMulExpr(MatrixInfixExpr):
     __slots__ = ()
     method_name = "mxm"
-    _infix = "@"
     _example_op = "plus_times"
+    _infix = "@"
 
     def __init__(self, left, right, *, nrows, ncols):
         super().__init__(left, right)
@@ -249,10 +251,11 @@ utils._output_types[MatrixMatMulExpr] = Matrix
 class ScalarMatMulExpr(InfixExprBase):
     __slots__ = ()
     method_name = "inner"
+    ndim = 0
     output_type = ScalarExpression
-    _infix = "@"
-    _example_op = "plus_times"
     shape = ()
+    _example_op = "plus_times"
+    _infix = "@"
     _is_scalar = True
 
     def new(self, dtype=None, *, name=None):

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -33,6 +33,7 @@ class Matrix(BaseType):
     """
 
     __slots__ = "_nrows", "_ncols", "_parent", "ss"
+    ndim = 2
     _is_transposed = False
     _name_counter = itertools.count()
 
@@ -1147,6 +1148,7 @@ Matrix.ss = class_property(Matrix.ss, ss)
 
 class MatrixExpression(BaseExpression):
     __slots__ = "_ncols", "_nrows"
+    ndim = 2
     output_type = Matrix
     _is_transposed = False
 
@@ -1264,6 +1266,7 @@ class MatrixExpression(BaseExpression):
 
 class TransposedMatrix:
     __slots__ = "_matrix", "_ncols", "_nrows", "__weakref__"
+    ndim = 2
     _is_scalar = False
     _is_transposed = True
 

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -19,6 +19,7 @@ class Scalar(BaseType):
     """
 
     __slots__ = "_is_empty"
+    ndim = 0
     shape = ()
     _is_scalar = True
     _name_counter = itertools.count()
@@ -269,6 +270,7 @@ class Scalar(BaseType):
 class ScalarExpression(BaseExpression):
     __slots__ = ()
     output_type = Scalar
+    ndim = 0
     shape = ()
     _is_scalar = True
 

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -2887,3 +2887,10 @@ def test_deprecated(A):
         A.ss.scan_rows()
     with pytest.warns(DeprecationWarning):
         A.ss.scan_columns()
+
+
+def test_ndim(A):
+    assert A.ndim == 2
+    assert A.ewise_mult(A).ndim == 2
+    assert (A & A).ndim == 2
+    assert (A @ A).ndim == 2

--- a/grblas/tests/test_scalar.py
+++ b/grblas/tests/test_scalar.py
@@ -312,3 +312,10 @@ def test_expr_is_like_scalar(s):
         "_expect_op",
         "_expect_type",
     }
+
+
+def test_ndim(s):
+    assert s.ndim == 0
+    v = grblas.Vector.from_values([1], [2])
+    assert v.inner(v).ndim == 0
+    assert (v @ v).ndim == 0

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1418,3 +1418,10 @@ def test_split(v):
     assert x2.isequal(expected2)
     assert x1.name == "split_0"
     assert x2.name == "split_1"
+
+
+def test_ndim(A, v):
+    assert v.ndim == 1
+    assert v.ewise_mult(v).ndim == 1
+    assert (v & v).ndim == 1
+    assert (A @ v).ndim == 1

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -31,6 +31,7 @@ class Vector(BaseType):
     """
 
     __slots__ = "_size", "ss"
+    ndim = 1
     _name_counter = itertools.count()
 
     def __init__(self, gb_obj, dtype, *, name=None):
@@ -751,6 +752,7 @@ Vector.ss = class_property(Vector.ss, ss)
 
 class VectorExpression(BaseExpression):
     __slots__ = "_size"
+    ndim = 1
     output_type = Vector
 
     def __init__(


### PR DESCRIPTION
Very small change that I've been considering for a couple years now.  `x.ndim` is sometimes convenient to write code that works with Scalar, Vector, or Matrix objects.  We've been using `len(x.shape)` fairly often in `dask-grblas`.