### PR TITLE
A few changes to be more friendly to `dask-grblas`.

### DIFF
--- a/grblas/expr.py
+++ b/grblas/expr.py
@@ -311,16 +311,16 @@ class Updater:
         return Assigner(self, resolved_indexes, is_submask=False)
 
     def _setitem(self, resolved_indexes, obj, *, is_submask):
-        # Occurs when user calls C(params)[index] = delayed
+        # Occurs when user calls C(params)[index] = expr
         if resolved_indexes.is_single_element and not self.kwargs:
             # Fast path using assignElement
             self.parent._assign_element(resolved_indexes, obj)
         else:
             mask = self.kwargs.get("mask")
-            delayed = self.parent._prep_for_assign(
+            expr = self.parent._prep_for_assign(
                 resolved_indexes, obj, mask=mask, is_submask=is_submask
             )
-            self.update(delayed)
+            self.update(expr)
 
     def __setitem__(self, keys, obj):
         if self.parent._is_scalar:
@@ -338,13 +338,13 @@ class Updater:
         else:
             raise TypeError("Remove Element only supports a single index")
 
-    def __lshift__(self, delayed):
-        # Occurs when user calls `C(params) << delayed`
-        self.parent._update(delayed, **self.kwargs)
+    def __lshift__(self, expr):
+        # Occurs when user calls `C(params) << expr`
+        self.parent._update(expr, **self.kwargs)
 
-    def update(self, delayed):
-        # Occurs when user calls `C(params).update(delayed)`
-        self.parent._update(delayed, **self.kwargs)
+    def update(self, expr):
+        # Occurs when user calls `C(params).update(expr)`
+        self.parent._update(expr, **self.kwargs)
 
     def __eq__(self, other):
         raise TypeError(f"__eq__ not defined for objects of type {type(self)}.")

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -102,8 +102,8 @@ class Matrix(BaseType):
         resolved_indexes = IndexerResolver(self, keys)
         return AmbiguousAssignOrExtract(self, resolved_indexes)
 
-    def __setitem__(self, keys, delayed):
-        Updater(self)[keys] = delayed
+    def __setitem__(self, keys, expr):
+        Updater(self)[keys] = expr
 
     def __contains__(self, index):
         extractor = self[index]
@@ -841,7 +841,7 @@ class Matrix(BaseType):
                         # Upcast v to a Matrix and use Matrix_assign
                         rows = _CArray([rows.scalar.value])
                         rowscalar = _CScalar(1)
-                        delayed = MatrixExpression(
+                        expr = MatrixExpression(
                             method_name,
                             "GrB_Matrix_assign",
                             [value._as_matrix(), rows, rowscalar, cols, colscalar],
@@ -862,7 +862,7 @@ class Matrix(BaseType):
                         # C[i, J] << v
                         cfunc_name = "GrB_Row_assign"
                         expr_repr = "[{1}, [{3} cols]] = {0.name}"
-                    delayed = MatrixExpression(
+                    expr = MatrixExpression(
                         method_name,
                         cfunc_name,
                         [value, rows, cols, colscalar],
@@ -885,7 +885,7 @@ class Matrix(BaseType):
                         # Upcast v to a Matrix and use Matrix_assign
                         cols = _CArray([cols.scalar.value])
                         colscalar = _CScalar(1)
-                        delayed = MatrixExpression(
+                        expr = MatrixExpression(
                             method_name,
                             "GrB_Matrix_assign",
                             [value._as_matrix(), rows, rowscalar, cols, colscalar],
@@ -905,7 +905,7 @@ class Matrix(BaseType):
                         # C[I, j] << v
                         cfunc_name = "GrB_Col_assign"
                         expr_repr = "[{1}, [{3} cols]] = {0.name}"
-                    delayed = MatrixExpression(
+                    expr = MatrixExpression(
                         method_name,
                         cfunc_name,
                         [value, rows, rowscalar, cols],
@@ -965,7 +965,7 @@ class Matrix(BaseType):
                 # C(M)[I, J] << A
                 cfunc_name = "GrB_Matrix_assign"
                 expr_repr = "[[{2} rows], [{4} cols]] = {0.name}"
-            delayed = MatrixExpression(
+            expr = MatrixExpression(
                 method_name,
                 cfunc_name,
                 [value, rows, rowscalar, cols, colscalar],
@@ -1009,7 +1009,7 @@ class Matrix(BaseType):
                     value_vector << value
 
                     # Row-only selection
-                    delayed = MatrixExpression(
+                    expr = MatrixExpression(
                         method_name,
                         cfunc_name,
                         [value_vector, rows, cols, colscalar],
@@ -1033,7 +1033,7 @@ class Matrix(BaseType):
                     value_vector << value
 
                     # Column-only selection
-                    delayed = MatrixExpression(
+                    expr = MatrixExpression(
                         method_name,
                         cfunc_name,
                         [value_vector, rows, rowscalar, cols],
@@ -1084,7 +1084,7 @@ class Matrix(BaseType):
                         colscalar = _CScalar(1)
                     cfunc_name = f"GrB_Matrix_assign_{value.dtype}"
                     expr_repr = "[[{2} rows], [{4} cols]] = {0}"
-                delayed = MatrixExpression(
+                expr = MatrixExpression(
                     method_name,
                     cfunc_name,
                     [_CScalar(value), rows, rowscalar, cols, colscalar],
@@ -1093,7 +1093,7 @@ class Matrix(BaseType):
                     ncols=self._ncols,
                     dtype=self.dtype,
                 )
-        return delayed
+        return expr
 
     def _delete_element(self, resolved_indexes):
         rowidx, colidx = resolved_indexes.indices

--- a/grblas/tests/conftest.py
+++ b/grblas/tests/conftest.py
@@ -58,3 +58,7 @@ def autocompute(func):
             return func(*args, **kwargs)
 
     return inner
+
+
+def compute(x):
+    return x

--- a/grblas/tests/test_formatting.py
+++ b/grblas/tests/test_formatting.py
@@ -2,10 +2,13 @@ import numpy as np
 import pytest
 
 import grblas
-from grblas import Matrix, Scalar, Vector, formatting, unary
+from grblas import formatting, unary
 from grblas.formatting import CSS_STYLE
 
 from .conftest import autocompute
+
+from grblas import Matrix, Scalar, Vector  # isort:skip
+
 
 try:
     import pandas as pd

--- a/grblas/tests/test_infix.py
+++ b/grblas/tests/test_infix.py
@@ -1,9 +1,11 @@
 from pytest import fixture, raises
 
-from grblas import Matrix, Scalar, Vector, monoid, op
+from grblas import monoid, op
 from grblas.exceptions import DimensionMismatch
 
 from .conftest import autocompute
+
+from grblas import Matrix, Scalar, Vector  # isort:skip
 
 
 @fixture

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -8,7 +8,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import grblas
-from grblas import Matrix, Scalar, Vector, agg, binary, dtypes, monoid, semiring, unary
+from grblas import agg, binary, dtypes, monoid, semiring, unary
 from grblas.exceptions import (
     DimensionMismatch,
     DomainMismatch,
@@ -17,7 +17,9 @@ from grblas.exceptions import (
     OutputNotEmpty,
 )
 
-from .conftest import autocompute
+from .conftest import autocompute, compute
+
+from grblas import Matrix, Scalar, Vector  # isort:skip
 
 
 @pytest.fixture
@@ -162,7 +164,7 @@ def test_resize(A):
     assert A.nrows == 10
     assert A.ncols == 11
     assert A.nvals == 12
-    assert A[9, 9].value is None
+    assert compute(A[9, 9].value) is None
     A.resize(4, 1)
     assert A.nrows == 4
     assert A.ncols == 1
@@ -240,7 +242,7 @@ def test_extract_element(A):
     assert A[1, 6].value == 4
     assert A.T[6, 1].value == 4
     s = A[0, 0].new()
-    assert s.value is None
+    assert compute(s.value) is None
     assert s.dtype == "INT64"
     s = A[1, 6].new(dtype=float)
     assert s.value == 4.0
@@ -248,7 +250,7 @@ def test_extract_element(A):
 
 
 def test_set_element(A):
-    assert A[1, 1].value is None
+    assert compute(A[1, 1].value) is None
     assert A[3, 0].value == 3
     A[1, 1].update(21)
     A[3, 0] << -5
@@ -259,7 +261,7 @@ def test_set_element(A):
 def test_remove_element(A):
     assert A[3, 0].value == 3
     del A[3, 0]
-    assert A[3, 0].value is None
+    assert compute(A[3, 0].value) is None
     assert A[6, 3].value == 7
     with pytest.raises(TypeError, match="Remove Element only supports"):
         del A[3:5, 3]
@@ -1326,7 +1328,7 @@ def test_reduce_agg_empty():
             assert we.isequal(w)
             if attr not in {"argmin", "argmax", "first_index", "last_index"}:
                 s = B.reduce_scalar(aggr).new()
-                assert s.value is None
+                assert compute(s.value) is None
 
 
 def test_reduce_row_udf(A):

--- a/grblas/tests/test_numpyops.py
+++ b/grblas/tests/test_numpyops.py
@@ -10,6 +10,7 @@ import grblas.binary.numpy as npbinary
 import grblas.monoid.numpy as npmonoid
 import grblas.semiring.numpy as npsemiring
 import grblas.unary.numpy as npunary
+from grblas import Vector
 from grblas.dtypes import _supports_complex
 
 
@@ -22,8 +23,8 @@ def test_numpyops_dir():
 
 @pytest.mark.slow
 def test_bool_doesnt_get_too_large():
-    a = grblas.Vector.from_values([0, 1, 2, 3], [True, False, True, False])
-    b = grblas.Vector.from_values([0, 1, 2, 3], [True, True, False, False])
+    a = Vector.from_values([0, 1, 2, 3], [True, False, True, False])
+    b = Vector.from_values([0, 1, 2, 3], [True, True, False, False])
     if grblas.config["mapnumpy"]:
         with pytest.raises(KeyError, match="plus does not work with BOOL"):
             z = a.ewise_mult(b, grblas.monoid.numpy.add).new()
@@ -42,13 +43,13 @@ def test_bool_doesnt_get_too_large():
 def test_npunary():
     L = list(range(5))
     data = [
-        [grblas.Vector.from_values([0, 1], [True, False]), np.array([True, False])],
-        [grblas.Vector.from_values(L, L), np.array(L, dtype=np.int64)],
-        [grblas.Vector.from_values(L, L, dtype="float64"), np.array(L, dtype=np.float64)],
+        [Vector.from_values([0, 1], [True, False]), np.array([True, False])],
+        [Vector.from_values(L, L), np.array(L, dtype=np.int64)],
+        [Vector.from_values(L, L, dtype="float64"), np.array(L, dtype=np.float64)],
     ]
     if _supports_complex:  # pragma: no branch
         data.append(
-            [grblas.Vector.from_values(L, L, dtype="FC64"), np.array(L, dtype=np.complex128)],
+            [Vector.from_values(L, L, dtype="FC64"), np.array(L, dtype=np.complex128)],
         )
     blacklist = {"BOOL": {"negative"}, "FC64": {"ceil", "floor", "trunc"}}
     isclose = grblas.binary.isclose(1e-7, 0)
@@ -76,7 +77,7 @@ def test_npunary():
                         compare_op = isclose
                     else:
                         compare_op = npbinary.equal
-            np_result = grblas.Vector.from_values(
+            np_result = Vector.from_values(
                 list(range(np_input.size)), list(np_result), dtype=gb_result.dtype
             )
             assert gb_result.nvals == np_result.size
@@ -98,20 +99,20 @@ def test_npbinary():
     index = list(range(len(values1)))
     data = [
         [
-            [grblas.Vector.from_values(index, values1), grblas.Vector.from_values(index, values2)],
+            [Vector.from_values(index, values1), Vector.from_values(index, values2)],
             [np.array(values1, dtype=np.int64), np.array(values2, dtype=np.int64)],
         ],
         [
             [
-                grblas.Vector.from_values(index, values1, dtype="float64"),
-                grblas.Vector.from_values(index, values2, dtype="float64"),
+                Vector.from_values(index, values1, dtype="float64"),
+                Vector.from_values(index, values2, dtype="float64"),
             ],
             [np.array(values1, dtype=np.float64), np.array(values2, dtype=np.float64)],
         ],
         [
             [
-                grblas.Vector.from_values([0, 1, 2, 3], [True, False, True, False]),
-                grblas.Vector.from_values([0, 1, 2, 3], [True, True, False, False]),
+                Vector.from_values([0, 1, 2, 3], [True, False, True, False]),
+                Vector.from_values([0, 1, 2, 3], [True, True, False, False]),
             ],
             [np.array([True, False, True, False]), np.array([True, True, False, False])],
         ],
@@ -120,8 +121,8 @@ def test_npbinary():
         data.append(
             [
                 [
-                    grblas.Vector.from_values(index, values1, dtype="FC64"),
-                    grblas.Vector.from_values(index, values2, dtype="FC64"),
+                    Vector.from_values(index, values1, dtype="FC64"),
+                    Vector.from_values(index, values2, dtype="FC64"),
                 ],
                 [np.array(values1, dtype=np.complex128), np.array(values2, dtype=np.complex128)],
             ],
@@ -147,7 +148,7 @@ def test_npbinary():
                     np_result = getattr(np, binary_name)(np_left, np_right)
                     compare_op = npbinary.equal
 
-            np_result = grblas.Vector.from_values(
+            np_result = Vector.from_values(
                 np.arange(np_left.size), np_result, dtype=gb_result.dtype
             )
 
@@ -175,20 +176,20 @@ def test_npmonoid():
     index = list(range(len(values1)))
     data = [
         [
-            [grblas.Vector.from_values(index, values1), grblas.Vector.from_values(index, values2)],
+            [Vector.from_values(index, values1), Vector.from_values(index, values2)],
             [np.array(values1, dtype=int), np.array(values2, dtype=int)],
         ],
         [
             [
-                grblas.Vector.from_values(index, values1, dtype="float64"),
-                grblas.Vector.from_values(index, values2, dtype="float64"),
+                Vector.from_values(index, values1, dtype="float64"),
+                Vector.from_values(index, values2, dtype="float64"),
             ],
             [np.array(values1, dtype=np.float64), np.array(values2, dtype=np.float64)],
         ],
         [
             [
-                grblas.Vector.from_values([0, 1, 2, 3], [True, False, True, False]),
-                grblas.Vector.from_values([0, 1, 2, 3], [True, True, False, False]),
+                Vector.from_values([0, 1, 2, 3], [True, False, True, False]),
+                Vector.from_values([0, 1, 2, 3], [True, True, False, False]),
             ],
             [np.array([True, False, True, False]), np.array([True, True, False, False])],
         ],
@@ -198,8 +199,8 @@ def test_npmonoid():
     #     data.append(
     #         [
     #             [
-    #                 grblas.Vector.from_values(index, values1, dtype="FC64"),
-    #                 grblas.Vector.from_values(index, values2, dtype="FC64"),
+    #                 Vector.from_values(index, values1, dtype="FC64"),
+    #                 Vector.from_values(index, values2, dtype="FC64"),
     #             ],
     #             [
     #                 np.array(values1, dtype=np.complex128),
@@ -222,7 +223,7 @@ def test_npmonoid():
             with np.errstate(divide="ignore", over="ignore", under="ignore", invalid="ignore"):
                 gb_result = gb_left.ewise_mult(gb_right, op).new()
                 np_result = getattr(np, binary_name)(np_left, np_right)
-            np_result = grblas.Vector.from_values(
+            np_result = Vector.from_values(
                 np.arange(np_left.size), np_result, dtype=gb_result.dtype
             )
             assert gb_result.nvals == np_result.size

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -3,22 +3,12 @@ import itertools
 import numpy as np
 import pytest
 
-import grblas
-from grblas import (
-    Matrix,
-    Vector,
-    agg,
-    binary,
-    dtypes,
-    exceptions,
-    lib,
-    monoid,
-    op,
-    operator,
-    semiring,
-    unary,
-)
+import grblas as gb
+from grblas import agg, binary, dtypes, lib, monoid, op, operator, semiring, unary
+from grblas.exceptions import DomainMismatch, UdfParseError
 from grblas.operator import BinaryOp, Monoid, Semiring, UnaryOp, get_semiring
+
+from grblas import Matrix, Vector  # isort:skip
 
 
 def orig_types(op):
@@ -149,7 +139,7 @@ def test_unaryop_udf():
     with pytest.raises(TypeError, match="UDF argument must be a function"):
         UnaryOp.register_new("bad", object())
     assert not hasattr(unary, "bad")
-    with pytest.raises(exceptions.UdfParseError, match="Unable to parse function using Numba"):
+    with pytest.raises(UdfParseError, match="Unable to parse function using Numba"):
         UnaryOp.register_new("bad", lambda x: v)
 
 
@@ -223,7 +213,7 @@ def test_binaryop_parameterized():
     with pytest.raises(TypeError, match="UDF argument must be a function"):
         BinaryOp.register_new("bad", object())
     assert not hasattr(binary, "bad")
-    with pytest.raises(exceptions.UdfParseError, match="Unable to parse function using Numba"):
+    with pytest.raises(UdfParseError, match="Unable to parse function using Numba"):
         BinaryOp.register_new("bad", lambda x, y: v)
 
     def my_add(x, y):
@@ -293,7 +283,7 @@ def test_monoid_parameterized():
     fv = v.apply(unary.identity).new(dtype=dtypes.FP64)
     bin_op = BinaryOp.register_anonymous(logaddexp, parameterized=True)
     Monoid.register_new("_user_defined_monoid", bin_op, -np.inf)
-    monoid = grblas.monoid._user_defined_monoid
+    monoid = gb.monoid._user_defined_monoid
     fv2 = fv.ewise_mult(fv, monoid(2)).new()
     plus1 = UnaryOp.register_anonymous(lambda x: x + 1)
     expected = fv.apply(plus1).new()
@@ -525,9 +515,9 @@ def test_monoid_udf():
     result = Vector.from_values([0, 1, 2, 3], [4, 2, 3, 4], dtype=dtypes.INT32)
     assert w.isequal(result)
 
-    with pytest.raises(exceptions.DomainMismatch):
+    with pytest.raises(DomainMismatch):
         Monoid.register_anonymous(binary.plus_plus_one, {"BOOL": True})
-    with pytest.raises(exceptions.DomainMismatch):
+    with pytest.raises(DomainMismatch):
         Monoid.register_anonymous(binary.plus_plus_one, {"BOOL": -1})
 
 
@@ -599,7 +589,7 @@ def test_nested_names():
 
     UnaryOp.register_new("incrementers.plus_four", plus_four)
     assert hasattr(unary.incrementers, "plus_four")
-    assert hasattr(grblas.op.incrementers, "plus_four")  # Also save it to `grblas.op`!
+    assert hasattr(op.incrementers, "plus_four")  # Also save it to `grblas.op`!
     v << v.apply(unary.incrementers.plus_four)  # this is in addition to the plus_three earlier
     result2 = Vector.from_values([0, 1, 3], [8, 9, 3], dtype=dtypes.INT32)
     assert v.isequal(result2), v
@@ -617,8 +607,6 @@ def test_nested_names():
 
 @pytest.mark.slow
 def test_op_namespace():
-    from grblas import op
-
     assert op.abs is unary.abs
     assert op.minus is binary.minus
     assert op.plus is binary.plus

--- a/grblas/tests/test_prefix_scan.py
+++ b/grblas/tests/test_prefix_scan.py
@@ -2,7 +2,9 @@ import numpy as np
 import pytest
 
 import grblas as gb
-from grblas import Matrix, Vector, binary, monoid
+from grblas import binary, monoid
+
+from grblas import Matrix, Vector  # isort:skip
 
 try:
     # gb.io.to_numpy currently requires scipy

--- a/grblas/tests/test_resolving.py
+++ b/grblas/tests/test_resolving.py
@@ -1,8 +1,9 @@
 import pytest
 
-import grblas
-from grblas import Matrix, Vector, binary, dtypes, unary
+from grblas import binary, dtypes, replace, unary
 from grblas.expr import Updater
+
+from grblas import Matrix, Scalar, Vector  # isort:skip
 
 
 def test_from_values_dtype_resolving():
@@ -62,7 +63,7 @@ def test_order_of_updater_params_does_not_matter():
     assert v.isequal(result)
     # replace, mask=, accum=
     v = Vector.from_values([0, 1, 2, 3], [4, 3, 2, 1])
-    v(grblas.replace, mask=mask.V, accum=accum) << u.ewise_mult(u, binary.times)
+    v(replace, mask=mask.V, accum=accum) << u.ewise_mult(u, binary.times)
     assert v.isequal(result)
 
 
@@ -75,12 +76,12 @@ def test_updater_replace_no_mask():
     with pytest.raises(
         TypeError, match="'replace' argument may only be True if a mask is provided"
     ):
-        u(grblas.replace)
+        u(replace)
 
 
 def test_replace_repr():
-    assert repr(grblas.replace) == "replace"
-    assert str(grblas.replace) == "replace"
+    assert repr(replace) == "replace"
+    assert str(replace) == "replace"
 
 
 def test_updater_repeat_argument_types():
@@ -167,7 +168,7 @@ def test_bad_extract_with_updater():
         u << u()[[1, 2]]
     with pytest.raises(TypeError, match="mask is not allowed for single element extraction"):
         u[0].new(mask=u.S)
-    s = grblas.Scalar.from_value(10)
+    s = Scalar.from_value(10)
     with pytest.raises(TypeError, match="Indexing not supported for Scalars"):
         del s()[0]
     with pytest.raises(TypeError, match="Indexing not supported for Scalars"):

--- a/grblas/tests/test_scalar.py
+++ b/grblas/tests/test_scalar.py
@@ -5,11 +5,12 @@ import weakref
 import numpy as np
 import pytest
 
-import grblas
-from grblas import Scalar, binary, dtypes
+from grblas import binary, dtypes, replace
 from grblas.scalar import _CScalar
 
-from .conftest import autocompute
+from .conftest import autocompute, compute
+
+from grblas import Scalar, Vector  # isort:skip
 
 
 @pytest.fixture
@@ -20,15 +21,15 @@ def s():
 def test_new():
     s = Scalar.new(dtypes.INT8)
     assert s.dtype == "INT8"
-    assert s.value is None
+    assert compute(s.value) is None
     s.value = 0
-    assert s.is_empty is False
+    assert compute(s.is_empty) is False
     s2 = Scalar.new(bool)
     assert s2.dtype == "BOOL"
-    assert s2.value is None
+    assert compute(s2.value) is None
     assert bool(s2) is False
     s2.value = False
-    assert s2.is_empty is False
+    assert compute(s2.is_empty) is False
 
 
 def test_dup(s):
@@ -57,16 +58,16 @@ def test_dup(s):
         assert s5.dtype == dtype and s5.value == val
         s6 = s_empty.dup(dtype=dtype)
         assert s6.is_empty
-        assert s6.value is None
+        assert compute(s6.value) is None
         s7 = s_unempty.dup(dtype=dtype)
         assert not s7.is_empty
-        assert s7.value is not None
+        assert compute(s7.value) is not None
 
 
 def test_from_value():
     s = Scalar.from_value(False)
     assert s.dtype == bool
-    assert s.value is False
+    assert compute(s.value) is False
     s2 = Scalar.from_value(-1.1)
     assert s2.dtype == "FP64"
     assert s2.value == -1.1
@@ -79,13 +80,13 @@ def test_clear(s):
     assert s.value == 5
     assert not s.is_empty
     s.clear()
-    assert s.value is None
+    assert compute(s.value) is None
     assert s.is_empty
     s2 = Scalar.from_value(True)
-    assert s2.value is True
+    assert compute(s2.value) is True
     assert not s2.is_empty
     s2.clear()
-    assert s2.value is None
+    assert compute(s2.value) is None
     assert s2.is_empty
 
 
@@ -203,7 +204,7 @@ def test_update(s):
     with pytest.raises(TypeError, match="'replace' argument may not be True for Scalar"):
         s(replace=True)
     with pytest.raises(TypeError, match="'replace' argument may not be True for Scalar"):
-        s(grblas.replace)
+        s(replace)
 
 
 def test_not_hashable(s):
@@ -266,13 +267,13 @@ def test_neg():
             assert s == -minus_s
             assert (-s).value == minus_s.value
             assert empty == -empty
-            assert (-empty).value is None
+            assert compute((-empty).value) is None
 
 
 def test_invert():
     empty = Scalar.new(bool)
     assert empty == ~empty
-    assert (~empty).value is None
+    assert compute((~empty).value) is None
     not_s = Scalar.from_value(0, dtype=bool)
     s = Scalar.from_value(1, dtype=bool)
     assert ~s == not_s
@@ -289,7 +290,7 @@ def test_wait(s):
 
 @autocompute
 def test_expr_is_like_scalar(s):
-    v = grblas.Vector.from_values([1], [2])
+    v = Vector.from_values([1], [2])
     attrs = {attr for attr, val in inspect.getmembers(s)}
     expr_attrs = {attr for attr, val in inspect.getmembers(v.inner(v))}
     infix_attrs = {attr for attr, val in inspect.getmembers(v @ v)}

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -8,7 +8,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import grblas
-from grblas import Matrix, Scalar, Vector, agg, binary, dtypes, monoid, semiring, unary
+from grblas import agg, binary, dtypes, monoid, semiring, unary
 from grblas.exceptions import (
     DimensionMismatch,
     IndexOutOfBound,
@@ -16,7 +16,9 @@ from grblas.exceptions import (
     OutputNotEmpty,
 )
 
-from .conftest import autocompute
+from .conftest import autocompute, compute
+
+from grblas import Matrix, Scalar, Vector  # isort:skip
 
 
 @pytest.fixture
@@ -121,14 +123,16 @@ def test_from_values_scalar():
     assert u.size == 4
     assert u.nvals == 3
     assert u.dtype == dtypes.INT64
-    assert u.ss.is_iso
+    if hasattr(u, "ss"):  # pragma: no branch
+        assert u.ss.is_iso
     assert u.reduce(monoid.any).new() == 7
 
     # ignore duplicate indices; iso trumps duplicates!
     u = Vector.from_values([0, 1, 1, 3], 7)
     assert u.size == 4
     assert u.nvals == 3
-    assert u.ss.is_iso
+    if hasattr(u, "ss"):  # pragma: no branch
+        assert u.ss.is_iso
     assert u.reduce(monoid.any).new() == 7
     with pytest.raises(ValueError, match="dup_op must be None"):
         Vector.from_values([0, 1, 1, 3], 7, dup_op=binary.plus)
@@ -146,7 +150,7 @@ def test_resize(v):
     v.resize(20)
     assert v.size == 20
     assert v.nvals == 4
-    assert v[19].value is None
+    assert compute(v[19].value) is None
     v.resize(4)
     assert v.size == 4
     assert v.nvals == 2
@@ -234,7 +238,7 @@ def test_extract_element(v):
 
 
 def test_set_element(v):
-    assert v[0].value is None
+    assert compute(v[0].value) is None
     assert v[1].value == 1
     v[0] = 12
     v[1] << 9
@@ -245,7 +249,7 @@ def test_set_element(v):
 def test_remove_element(v):
     assert v[1].value == 1
     del v[1]
-    assert v[1].value is None
+    assert compute(v[1].value) is None
     assert v[4].value == 2
     with pytest.raises(TypeError, match="Remove Element only supports"):
         del v[1:3]
@@ -716,7 +720,7 @@ def test_reduce_agg_empty():
         if not isinstance(aggr, agg.Aggregator):
             continue
         s = v.reduce(aggr).new()
-        assert s.value is None
+        assert compute(s.value) is None
 
 
 def test_reduce_coerce_dtype(v):

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -104,8 +104,8 @@ class Vector(BaseType):
         resolved_indexes = IndexerResolver(self, keys)
         return AmbiguousAssignOrExtract(self, resolved_indexes)
 
-    def __setitem__(self, keys, delayed):
-        Updater(self)[keys] = delayed
+    def __setitem__(self, keys, expr):
+        Updater(self)[keys] = expr
 
     def __contains__(self, index):
         extractor = self[index]


### PR DESCRIPTION
Most notably, `dask_grblas` is now able to automatically copy and convert testsfrom `grblas`.  This is important so that `dask-grblas` is able to better match the `grblas` API *and* to stay up to date more easily.  It is the burden of `dask-grblas` developers to ensure `grblas` tests may be copied over.

This entails adding a superfluous (for `grblas`) function `compute` in a few tests. It also includes separating imports of `Matrix`, `Vector`, and `Scalar` so these may be easily imported from `dask_grblas` instead of `grblas`. Finally, I changed some argument names from `delayed` to `expr`, since `delayed` means something else in `dask_grblas`.