### PR TITLE
Add `.ss.compactify` to Vector and Matrix objects

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -61,10 +61,8 @@ jobs:
               # I can't get pip install from git to work, so git clone instead.
               # pip install git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas
               conda install -c conda-forge cython
-              # git clone --depth=1 https://github.com/GraphBLAS/python-suitesparse-graphblas.git ssgb
-              git clone https://github.com/GraphBLAS/python-suitesparse-graphblas.git ssgb
+              git clone --depth=1 https://github.com/GraphBLAS/python-suitesparse-graphblas.git ssgb
               pushd ssgb
-              git checkout 7f3aa18b14f678650dcef98cdebf41bb7e62f47b  # wait until we support v6.0.2
               python setup.py install
               popd
           elif [[ ${{ matrix.sourcetype }} == "conda-forge" ]]; then

--- a/grblas/_slice.py
+++ b/grblas/_slice.py
@@ -19,6 +19,8 @@ def slice_to_index(index, size):
     # For non-SuiteSparse, do: index = list(range(size)[index])
     # SuiteSparse indexing is inclusive for both start and stop, and unsigned.
     if step < 0:
+        if start < 0:
+            start = stop = 0  # Must be empty
         return AxisIndex(length, _CArray([start, stop + 1, -step]), gxb_backwards)
     if stop > 0:
         stop -= 1

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -3736,11 +3736,17 @@ class ss:
         Parameters
         ----------
         how : {"first", "last", "smallest", "largest", "random"}, optional
-
+            How to compress the values:
+            - first : take the values furthest to the left
+            - last : take the values furthest to the right
+            - smallest : take the smallest values (if tied, may take any)
+            - largest : take the largest values (if tied, may take any)
+            - random : take values randomly with equal probability and without replacement
         reverse : bool, default False
-
+            Reverse the values in each row when True
         asindex : bool, default False
-
+            Return the column index of the value when True.  If there are ties for
+            "smallest" and "largest", then any valid index may be returned.
         ncols : int, optional
             The number of columns of the returned Matrix.  If not specified, then
             the Matrix will be "compacted" to the smallest ncols that doesn't lose
@@ -3749,8 +3755,6 @@ class ss:
         **THIS API IS EXPERIMENTAL AND MAY CHANGE**
 
         """
-        # TODO: sort argument?  how=random -> unweighted and weighted, with and w/o replacement
-        # first/last - leftmost/rightmost - topmost/bottommost ?
         return self._compactify(
             how, reverse, asindex, "ncols", ncols, "hypercsr", "col_indices", name
         )
@@ -3758,6 +3762,32 @@ class ss:
     def compactify_columnwise(
         self, how="first", nrows=None, *, reverse=False, asindex=False, name=None
     ):
+        """Shift all values to the top so all values in a column are contiguous.
+
+        This returns a new Matrix.
+
+        Parameters
+        ----------
+        how : {"first", "last", "smallest", "largest", "random"}, optional
+            How to compress the values:
+            - first : take the values furthest to the top
+            - last : take the values furthest to the bottom
+            - smallest : take the smallest values (if tied, may take any)
+            - largest : take the largest values (if tied, may take any)
+            - random : take values randomly with equal probability and without replacement
+        reverse : bool, default False
+            Reverse the values in each column when True
+        asindex : bool, default False
+            Return the row index of the value when True.  If there are ties for
+            "smallest" and "largest", then any valid index may be returned.
+        nrows : int, optional
+            The number of rows of the returned Matrix.  If not specified, then
+            the Matrix will be "compacted" to the smallest nrows that doesn't lose
+            values.
+
+        **THIS API IS EXPERIMENTAL AND MAY CHANGE**
+
+        """
         return self._compactify(
             how, reverse, asindex, "nrows", nrows, "hypercsc", "row_indices", name
         )

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -3782,9 +3782,10 @@ class ss:
                 reverse = False
             if not asindex:
                 how = "finished"
+                values_need_trimmed = False
                 reverse = False
             else:
-                del info["is_iso"]
+                info["is_iso"] = False
 
         if how == "random":
             # Random without replacement

--- a/grblas/_ss/vector.py
+++ b/grblas/_ss/vector.py
@@ -1232,7 +1232,7 @@ class ss:
         else:
             raise NotImplementedError(fmt)
 
-    def selectk(self, how, k):
+    def selectk(self, how, k, *, name=None):
         """Select (up to) k elements.
 
         Parameters
@@ -1277,6 +1277,22 @@ class ss:
         return gb.Vector.ss.import_sparse(
             **newinfo,
             take_ownership=True,
+            name=name,
+        )
+
+    def compactify(self, *, size=None, name=None):
+        info = self.export("sparse", sort=True)
+        N = len(info["indices"])
+        if size is None:
+            size = N
+        elif size < N:
+            1 / 0  # TODO
+            N = size
+        indices = np.arange(N, dtype=np.uint64)
+        newinfo = dict(info, indices=indices, size=N)
+        return gb.Vector.ss.import_sparse(
+            **newinfo,
+            name=name,
         )
 
 

--- a/grblas/_ss/vector.py
+++ b/grblas/_ss/vector.py
@@ -1281,6 +1281,31 @@ class ss:
         )
 
     def compactify(self, how="first", size=None, *, reverse=False, asindex=False, name=None):
+        """Shift all values to the beginning so all values are contiguous.
+
+        This returns a new Vector.
+
+        Parameters
+        ----------
+        how : {"first", "last", "smallest", "largest", "random"}, optional
+            How to compress the values:
+            - first : take the values nearest the beginning
+            - last : take the values nearest the end
+            - smallest : take the smallest values (if tied, may take any)
+            - largest : take the largest values (if tied, may take any)
+            - random : take values randomly with equal probability and without replacement
+        reverse : bool, default False
+            Reverse the values when True
+        asindex : bool, default False
+            Return the index of the value when True.  If there are ties for
+            "smallest" and "largest", then any valid index may be returned.
+        size : int, optional
+            The size of the returned Vector.  If not specified, then the Vector
+            will be "compacted" to the smallest size that doesn't lose values.
+
+        **THIS API IS EXPERIMENTAL AND MAY CHANGE**
+
+        """
         how = how.lower()
         if how not in {"first", "last", "smallest", "largest", "random"}:
             raise ValueError(

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -117,6 +117,7 @@ class Matrix(BaseType):
         return not scalar.is_empty
 
     def __iter__(self):
+        self.wait()  # sort in SS
         rows, columns, values = self.to_values()
         return zip(rows.flat, columns.flat)
 
@@ -1374,6 +1375,7 @@ class TransposedMatrix:
     # Misc.
     isequal = Matrix.isequal
     isclose = Matrix.isclose
+    wait = Matrix.wait
     _extract_element = Matrix._extract_element
     _prep_for_extract = Matrix._prep_for_extract
     __eq__ = Matrix.__eq__

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -2881,6 +2881,133 @@ def test_lastk(A):
     assert B.isequal(A)
 
 
+def test_compactify(A):
+    rows = [0, 0, 1, 1, 2, 3, 3, 4, 5, 6, 6, 6]
+    new_cols = [0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 2]
+    orig_cols = [1, 3, 4, 6, 5, 0, 2, 5, 2, 2, 3, 4]
+
+    def check(A, expected, *args, stop=0, **kwargs):
+        B = A.ss.compactify_rowwise(*args, **kwargs)
+        assert B.isequal(expected)
+        for n in reversed(range(stop, 4)):
+            expected = expected[:, :n].new()
+            B = A.ss.compactify_rowwise(*args, ncols=n, **kwargs)
+            assert B.isequal(expected)
+
+    def reverse(A):
+        return A[:, ::-1].new().ss.compactify_rowwise("first", A.ncols)
+
+    def check_reverse(A, expected, *args, stop=0, **kwargs):
+        B = A.ss.compactify_rowwise(*args, reverse=True, **kwargs)
+        C = reverse(expected)
+
+        assert B.isequal(C)
+        for n in reversed(range(stop, 4)):
+            C = reverse(expected[:, :n].new())
+            B = A.ss.compactify_rowwise(*args, ncols=n, reverse=True, **kwargs)
+            assert B.isequal(C)
+
+    expected = Matrix.from_values(
+        rows,
+        new_cols,
+        [2, 3, 8, 4, 1, 3, 3, 7, 1, 5, 7, 3],
+        nrows=A.nrows,
+        ncols=3,
+    )
+    check(A, expected, "first")
+    check_reverse(A, expected, "first")
+    check(A, reverse(expected), "last")
+    check_reverse(A, reverse(expected), "last")
+
+    expected = Matrix.from_values(
+        rows,
+        new_cols,
+        orig_cols,
+        nrows=A.nrows,
+        ncols=3,
+    )
+    check(A, expected, "first", asindex=True)
+    check_reverse(A, expected, "first", asindex=True)
+    check(A, reverse(expected), "last", asindex=True)
+    check_reverse(A, reverse(expected), "last", asindex=True)
+
+    expected = Matrix.from_values(
+        rows,
+        new_cols,
+        [2, 3, 4, 8, 1, 3, 3, 7, 1, 3, 5, 7],
+        nrows=A.nrows,
+        ncols=3,
+    )
+    check(A, expected, "smallest")
+    check_reverse(A, expected, "smallest")
+    check(A, reverse(expected), "largest")
+    check_reverse(A, reverse(expected), "largest")
+
+    expected = Matrix.from_values(
+        rows,
+        new_cols,
+        [1, 3, 6, 4, 5, 0, 2, 5, 2, 4, 2, 3],
+        nrows=A.nrows,
+        ncols=3,
+    )
+    check(A, expected, "smallest", asindex=True, stop=2)
+    check_reverse(A, expected, "smallest", asindex=True, stop=2)
+    check(A, reverse(expected), "largest", asindex=True, stop=2)
+    check_reverse(A, reverse(expected), "largest", asindex=True, stop=2)
+
+    def compare(A, expected, isequal=True, **kwargs):
+        for _ in range(100):
+            B = A.ss.compactify_rowwise("random", **kwargs)
+            if B.isequal(expected) == isequal:
+                break
+        else:
+            raise AssertionError("random failed")
+
+    with pytest.raises(AssertionError):
+        compare(A, A[:, ::-1].new())
+
+    for asindex in [False, True]:
+        compare(A, A.ss.compactify_rowwise("first", asindex=asindex), asindex=asindex)
+        compare(A, A.ss.compactify_rowwise("first", 3, asindex=asindex), ncols=3, asindex=asindex)
+        compare(A, A.ss.compactify_rowwise("first", 2, asindex=asindex), ncols=2, asindex=asindex)
+        compare(
+            A,
+            A.ss.compactify_rowwise("first", 2, asindex=asindex),
+            ncols=2,
+            asindex=asindex,
+            isequal=False,
+        )
+        compare(A, A.ss.compactify_rowwise("first", 1, asindex=asindex), ncols=1, asindex=asindex)
+        compare(
+            A,
+            A.ss.compactify_rowwise("first", 1, asindex=asindex),
+            ncols=1,
+            asindex=asindex,
+            isequal=False,
+        )
+        compare(A, A.ss.compactify_rowwise("last", 1, asindex=asindex), ncols=1, asindex=asindex)
+        compare(
+            A, A.ss.compactify_rowwise("smallest", 1, asindex=asindex), ncols=1, asindex=asindex
+        )
+        compare(A, A.ss.compactify_rowwise("largest", 1, asindex=asindex), ncols=1, asindex=asindex)
+        compare(A, A.ss.compactify_rowwise("first", 0, asindex=asindex), ncols=0, asindex=asindex)
+
+    B = A.ss.compactify_columnwise("first", nrows=1)
+    expected = Matrix.from_values(
+        [0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 2, 3, 4, 5, 6],
+        [3, 2, 3, 3, 8, 1, 4],
+    )
+    assert B.isequal(expected)
+    B = A.ss.compactify_columnwise("last", nrows=1, asindex=True)
+    expected = Matrix.from_values(
+        [0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 2, 3, 4, 5, 6],
+        [3, 0, 6, 6, 6, 4, 1],
+    )
+    assert B.isequal(expected)
+
+
 def test_deprecated(A):
     with pytest.warns(DeprecationWarning):
         A.reduce_rows()

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -2561,7 +2561,7 @@ def test_expr_is_like_matrix(A):
     }
     # TransposedMatrix is used differently than other expressions,
     # so maybe it shouldn't support everything.
-    assert attrs - transposed_attrs == (expected | {"S", "V", "ss", "to_pygraphblas", "wait"}) - {
+    assert attrs - transposed_attrs == (expected | {"S", "V", "ss", "to_pygraphblas"}) - {
         "_prep_for_extract",
         "_extract_element",
     }

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -2882,6 +2882,7 @@ def test_lastk(A):
 
 
 @pytest.mark.parametrize("do_iso", [False, True])
+@pytest.mark.slow
 def test_compactify(A, do_iso):
     if do_iso:
         r, c, v = A.to_values()
@@ -2904,7 +2905,6 @@ def test_compactify(A, do_iso):
     def check_reverse(A, expected, *args, stop=0, **kwargs):
         B = A.ss.compactify_rowwise(*args, reverse=True, **kwargs)
         C = reverse(expected)
-
         assert B.isequal(C)
         for n in reversed(range(stop, 4)):
             C = reverse(expected[:, :n].new())
@@ -2961,7 +2961,7 @@ def test_compactify(A, do_iso):
         check_reverse(A, reverse(expected), "largest", asindex=True, stop=2)
 
     def compare(A, expected, isequal=True, **kwargs):
-        for _ in range(100):
+        for _ in range(1000):
             B = A.ss.compactify_rowwise("random", **kwargs)
             if B.isequal(expected) == isequal:
                 break

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -119,6 +119,7 @@ class Vector(BaseType):
         return not scalar.is_empty
 
     def __iter__(self):
+        self.wait()  # sort in SS
         indices, values = self.to_values()
         return indices.flat
 


### PR DESCRIPTION
Vectors are still TODO.  We also need tests.

We had previously spec'ed out having `sort=` argument to compactify.
We can still add this, but I don't know if it's really necessary.