### PR TITLE
Add `.__sizeof__` method to Matrix and Vector objects.

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyver: ["3.8", "3.9", "3.10"]
+        pyver: ["3.8", "3.9"]
         testopts:
           - "--blocking"
           - "--non-blocking --record --runslow"

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyver: ["3.8", "3.9"]
+        pyver: ["3.8", "3.9", "3.10"]
         testopts:
           - "--blocking"
           - "--non-blocking --record --runslow"
@@ -61,10 +61,8 @@ jobs:
               # I can't get pip install from git to work, so git clone instead.
               # pip install git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas
               conda install -c conda-forge cython
-              # git clone --depth=1 https://github.com/GraphBLAS/python-suitesparse-graphblas.git ssgb
-              git clone https://github.com/GraphBLAS/python-suitesparse-graphblas.git ssgb
+              git clone --depth=1 https://github.com/GraphBLAS/python-suitesparse-graphblas.git ssgb
               pushd ssgb
-              git checkout 7f3aa18b14f678650dcef98cdebf41bb7e62f47b  # wait until we support v6.0.2
               python setup.py install
               popd
           elif [[ ${{ matrix.sourcetype }} == "conda-forge" ]]; then

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -120,6 +120,12 @@ class Matrix(BaseType):
         rows, columns, values = self.to_values()
         return zip(rows.flat, columns.flat)
 
+    def __sizeof__(self):
+        size = ffi_new("size_t*")
+        scalar = Scalar(size, _INDEX, name="s_size", empty=True)
+        call("GxB_Matrix_memoryUsage", [_Pointer(scalar), self])
+        return size[0] + object.__sizeof__(self)
+
     def isequal(self, other, *, check_dtype=False):
         """
         Check for exact equality (same size, same empty values)

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1,6 +1,7 @@
 import inspect
 import itertools
 import pickle
+import sys
 import weakref
 
 import numpy as np
@@ -2897,3 +2898,7 @@ def test_ndim(A):
     assert A.ewise_mult(A).ndim == 2
     assert (A & A).ndim == 2
     assert (A @ A).ndim == 2
+
+
+def test_sizeof(A):
+    assert sys.getsizeof(A) > A.nvals * 16

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1,6 +1,7 @@
 import inspect
 import itertools
 import pickle
+import sys
 import weakref
 
 import numpy as np
@@ -1444,3 +1445,7 @@ def test_ndim(A, v):
     assert v.ewise_mult(v).ndim == 1
     assert (v & v).ndim == 1
     assert (A @ v).ndim == 1
+
+
+def test_sizeof(v):
+    assert sys.getsizeof(v) > v.nvals * 16

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -122,6 +122,12 @@ class Vector(BaseType):
         indices, values = self.to_values()
         return indices.flat
 
+    def __sizeof__(self):
+        size = ffi_new("size_t*")
+        scalar = Scalar(size, _INDEX, name="s_size", empty=True)
+        call("GxB_Vector_memoryUsage", [_Pointer(scalar), self])
+        return size[0] + object.__sizeof__(self)
+
     def isequal(self, other, *, check_dtype=False):
         """
         Check for exact equality (same size, same empty values)


### PR DESCRIPTION
We'll want the the dask distributed scheduler to know the size of objects so it can send them around effectively.