### PR TITLE
Allow reduce to scalar to result in empty scalar

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate grblas
-          conda install -c conda-forge pandas numba scipy networkx cffi
+          conda install -c conda-forge pandas numba scipy networkx cffi donfig
           if [[ ${{ matrix.sourcetype }} == "wheel" ]]; then
               pip install suitesparse-graphblas
           else
@@ -68,7 +68,7 @@ jobs:
           elif [[ ${{ matrix.sourcetype }} == "conda-forge" ]]; then
               conda install -c conda-forge python-suitesparse-graphblas
           fi
-          python setup.py develop
+          python setup.py develop --no-deps
       # - name: Optional pygraphblas
       #   if: contains(matrix.testopts, 'pygraphblas') && (matrix.pyver != 3.9)
       #   run: |
@@ -129,6 +129,7 @@ jobs:
 
   finish:
     needs: build_and_test
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Setup conda env

--- a/grblas/_agg.py
+++ b/grblas/_agg.py
@@ -118,10 +118,11 @@ class TypedAggregator:
         agg = self.parent
         if agg._monoid is not None:
             x = expr.args[0]
+            method = getattr(x, expr.method_name)
             if expr.output_type is Scalar:
-                expr = getattr(x, expr.method_name)(agg._monoid[self.type], allow_empty=True)
+                expr = method(agg._monoid[self.type], allow_empty=expr._is_empty)
             else:
-                expr = getattr(x, expr.method_name)(agg._monoid[self.type])
+                expr = method(agg._monoid[self.type])
             updater << expr
             if in_composite:
                 parent = updater.parent
@@ -453,7 +454,7 @@ def _argminmaxij(
                 return updater.parent
     elif expr.cfunc_name.startswith("GrB_Vector_reduce"):
         v = expr.args[0]
-        step1 = v.reduce(monoid).new()
+        step1 = v.reduce(monoid, allow_empty=False).new()
         masked = binary.eq(v, step1).new()
         masked(mask=masked.V, replace=True) << masked  # Could use select
         init = expr._new_matrix(bool, nrows=v._size, ncols=1)

--- a/grblas/_agg.py
+++ b/grblas/_agg.py
@@ -118,11 +118,10 @@ class TypedAggregator:
         agg = self.parent
         if agg._monoid is not None:
             x = expr.args[0]
-            expr = getattr(x, expr.method_name)(agg._monoid[self.type])
-            if expr.output_type is Scalar and x._nvals == 0:
-                # Don't set scalar output to monoid identity if empty
-                # Can we do this without checking nvals?  This is inefficient for dask-grblas
-                expr = expr._new_scalar(expr.dtype)
+            if expr.output_type is Scalar:
+                expr = getattr(x, expr.method_name)(agg._monoid[self.type], allow_empty=True)
+            else:
+                expr = getattr(x, expr.method_name)(agg._monoid[self.type])
             updater << expr
             if in_composite:
                 parent = updater.parent

--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -782,7 +782,7 @@ class ss:
                         f"GrB_Matrix_extractTuples_{parent.dtype.name}",
                         [rows, columns, None, _Pointer(scalar), parent],
                     )
-                    value = parent.reduce_scalar(gb.monoid.any).new().value
+                    value = parent.reduce_scalar(gb.monoid.any, allow_empty=False).new().value
                     rv = {
                         "format": "coo",
                         "nrows": nrows,

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -429,6 +429,8 @@ class BaseType:
             output_replace=replace,
         )
         if self._is_scalar:
+            if expr._is_empty:
+                return
             is_fake_scalar = expr.method_name == "inner"
             if is_fake_scalar:
                 from .vector import Vector

--- a/grblas/formatting.py
+++ b/grblas/formatting.py
@@ -109,10 +109,11 @@ def _update_matrix_dataframe(df, matrix, rows, row_offset, columns, column_offse
         if type(matrix) is TransposedMatrix:
             parent = matrix._matrix
             submatrix = Matrix.new(parent.dtype, parent._nrows, parent._ncols, name="")
-            # Get val to support iso-valued matrices
-            val = parent.reduce_scalar(monoid.any).new(name="")
-            submatrix(parent.S)[columns, rows] = val
-            submatrix(submatrix.S)[...] = parent
+            if parent._nvals > 0:
+                # Get val to support iso-valued matrices
+                val = parent.reduce_scalar(monoid.any, allow_empty=False).new(name="")
+                submatrix(parent.S)[columns, rows] = val
+                submatrix(submatrix.S)[...] = parent
             if row_offset is not None or column_offset is not None:
                 submatrix = submatrix[column_offset:, row_offset:].new(name="")
             submatrix = submatrix.T
@@ -120,9 +121,10 @@ def _update_matrix_dataframe(df, matrix, rows, row_offset, columns, column_offse
             if mask is None:
                 submatrix = Matrix.new(matrix.dtype, matrix._nrows, matrix._ncols, name="")
                 # Get val to support iso-valued matrices
-                val = matrix.reduce_scalar(monoid.any).new(name="")
-                submatrix(matrix.S)[rows, columns] = val
-                submatrix(submatrix.S)[...] = matrix
+                if matrix._nvals > 0:
+                    val = matrix.reduce_scalar(monoid.any).new(name="")
+                    submatrix(matrix.S)[rows, columns] = val
+                    submatrix(submatrix.S)[...] = matrix
             else:
                 submatrix = Matrix.new("UINT8", matrix._nrows, matrix._ncols, name="")
                 if mask.structure:
@@ -153,9 +155,10 @@ def _update_vector_dataframe(df, vector, columns, column_offset, *, mask=None):
         if mask is None:
             subvector = Vector.new(vector.dtype, vector._size, name="")
             # Get val to support iso-valued vectors
-            val = vector.reduce(monoid.any).new(name="")
-            subvector(vector.S)[columns] = val
-            subvector(subvector.S)[...] = vector
+            if vector._nvals > 0:
+                val = vector.reduce(monoid.any).new(name="")
+                subvector(vector.S)[columns] = val
+                subvector(subvector.S)[...] = vector
         else:
             subvector = Vector.new("UINT8", vector._size, name="")
             if mask.structure:

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -722,11 +722,14 @@ class Matrix(BaseType):
         )
         return self.reduce_columnwise(op)
 
-    def reduce_scalar(self, op=monoid.plus):
+    def reduce_scalar(self, op=monoid.plus, *, allow_empty=False):
         """
         GrB_Matrix_reduce
         Reduce all values into a scalar
         Default op is monoid.lor for boolean and monoid.plus otherwise
+
+        For empty Matrix objects, the result will be the monoid identity if
+        `allow_empty` is False or empty Scalar if `allow_empty` is True.
         """
         method_name = "reduce_scalar"
         op = get_typed_op(op, self.dtype, kind="binary")
@@ -746,6 +749,7 @@ class Matrix(BaseType):
             "GrB_Matrix_reduce_{output_dtype}",
             [self],
             op=op,  # to be determined later
+            is_empty=allow_empty and self._nvals == 0,
         )
 
     ##################################

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -181,7 +181,12 @@ class TypedBuiltinMonoid(TypedOpBase):
             from .vector import Vector
 
             with skip_record:
-                self._identity = Vector.new(self.type, size=1, name="").reduce(self).new().value
+                self._identity = (
+                    Vector.new(self.type, size=1, name="")
+                    .reduce(self, allow_empty=False)
+                    .new()
+                    .value
+                )
         return self._identity
 
     @property

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -279,11 +279,17 @@ class Scalar(BaseType):
 
 
 class ScalarExpression(BaseExpression):
-    __slots__ = ()
+    __slots__ = "_is_empty"
     output_type = Scalar
     ndim = 0
     shape = ()
     _is_scalar = True
+
+    def __init__(self, *args, is_empty=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        # The result may still be empty even if `_is_empty` is False.
+        # We set this to True when we need to coerce the result to be empty.
+        self._is_empty = is_empty
 
     def construct_output(self, dtype=None, *, name=None):
         if dtype is None:
@@ -291,6 +297,8 @@ class ScalarExpression(BaseExpression):
         return Scalar.new(dtype, name=name)
 
     def new(self, dtype=None, *, name=None):
+        if self._is_empty:
+            return self.construct_output(dtype, name=name)
         return super().new(dtype, name=name)
 
     dup = new

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -1163,6 +1163,13 @@ def test_reduce_agg(A):
     s3 = A.reduce_scalar(silly).new()
     assert s3.isclose(s1.value * s2.value)
 
+    B = Matrix.new(int, nrows=4, ncols=5)
+    assert B.reduce_scalar(agg.sum, allow_empty=True).new().is_empty
+    assert B.reduce_scalar(agg.sum, allow_empty=False).new() == 0
+    assert B.reduce_scalar(agg.vars, allow_empty=True).new().is_empty
+    with pytest.raises(ValueError):
+        B.reduce_scalar(agg.vars, allow_empty=False)
+
 
 def test_reduce_agg_argminmax(A):
     # reduce_rowwise

--- a/grblas/tests/test_scalar.py
+++ b/grblas/tests/test_scalar.py
@@ -310,7 +310,7 @@ def test_expr_is_like_scalar(s):
         "from_value",
         "update",
     }
-    assert attrs - expr_attrs == expected
+    assert attrs - expr_attrs == expected - {"_is_empty"}
     assert attrs - infix_attrs == expected | {
         "_expect_op",
         "_expect_type",

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -641,6 +641,17 @@ def test_reduce(v):
         b1.reduce()
 
 
+def test_reduce_empty():
+    w = Vector.new(int, 5)
+    s = Scalar.from_value(16)
+    s(accum=binary.times) << w.reduce(monoid.plus, allow_empty=True)
+    assert s == 16
+    s(accum=binary.times) << w.reduce(monoid.plus)
+    assert s == 0
+    assert w.reduce(monoid.plus, allow_empty=True).new().is_empty
+    assert w.reduce(monoid.plus, allow_empty=False).new() == 0
+
+
 def test_reduce_agg(v):
     s = v.reduce(agg.sum).new()
     assert s.dtype == "INT64"

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -646,10 +646,15 @@ def test_reduce_empty():
     s = Scalar.from_value(16)
     s(accum=binary.times) << w.reduce(monoid.plus, allow_empty=True)
     assert s == 16
-    s(accum=binary.times) << w.reduce(monoid.plus)
+    s(accum=binary.times) << w.reduce(monoid.plus, allow_empty=False)
     assert s == 0
     assert w.reduce(monoid.plus, allow_empty=True).new().is_empty
     assert w.reduce(monoid.plus, allow_empty=False).new() == 0
+    assert w.reduce(agg.sum, allow_empty=True).new().is_empty
+    assert w.reduce(agg.sum, allow_empty=False).new() == 0
+    assert w.reduce(agg.mean, allow_empty=True).new().is_empty
+    with pytest.raises(ValueError):
+        w.reduce(agg.mean, allow_empty=False)
 
 
 def test_reduce_agg(v):

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -538,11 +538,14 @@ class Vector(BaseType):
             size=self._size,
         )
 
-    def reduce(self, op=monoid.plus):
+    def reduce(self, op=monoid.plus, *, allow_empty=False):
         """
         GrB_Vector_reduce
         Reduce all values into a scalar
         Default op is monoid.lor for boolean and monoid.plus otherwise
+
+        For empty Vector objects, the result will be the monoid identity if
+        `allow_empty` is False or empty Scalar if `allow_empty` is True.
         """
         method_name = "reduce"
         op = get_typed_op(op, self.dtype, kind="binary")
@@ -555,6 +558,7 @@ class Vector(BaseType):
             "GrB_Vector_reduce_{output_dtype}",
             [self],
             op=op,  # to be determined later
+            is_empty=allow_empty and self._nvals == 0,
         )
 
     # Unofficial methods

--- a/notebooks/Example B.1 -- Level BFS.ipynb
+++ b/notebooks/Example B.1 -- Level BFS.ipynb
@@ -145,7 +145,7 @@
     "    # Compute the next frontier, masking out anything already assigned\n",
     "    q(~v.S, replace=True) << q.vxm(A, semiring.lor_land)\n",
     "    # If next frontier is empty, we're done\n",
-    "    succ << q.reduce(monoid.lor)\n",
+    "    succ << q.reduce(monoid.lor, allow_empty=False)\n",
     "    if not succ:\n",
     "        break\n",
     "v"
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "succ << q.reduce(monoid.lor)\n",
+    "succ << q.reduce(monoid.lor, allow_empty=False)\n",
     "print(\"Continue\" if succ else \"Done\")"
    ]
   },


### PR DESCRIPTION
Fixes #160

This should be able to speed up some aggregators in `dask-grblas`.