### PR TITLE
Autocompute `AmbiguousAssignOrExtract` as extract

### DIFF
--- a/grblas/_agg.py
+++ b/grblas/_agg.py
@@ -530,11 +530,11 @@ def _first_last(agg, updater, expr, *, in_composite, semiring):
         # Populate numpy array
         vals = np.empty(Is.size, dtype=A.dtype.np_type)
         for index, (i, j) in enumerate(zip(Is, Js)):
-            vals[index] = A[i, j].value
+            vals[index] = A[i, j].new().value
         # or Vector
         # v = expr._new_vector(A.dtype, size=A._nrows)
         # for i, j in zip(Is, Js):
-        #     v[i] = A[i, j].value
+        #     v[i] = A[i, j].new().value
         result = Vector.from_values(Is, vals, size=A._nrows)
         updater << result
         if in_composite:
@@ -544,7 +544,7 @@ def _first_last(agg, updater, expr, *, in_composite, semiring):
         init = expr._new_matrix(bool, nrows=v._size, ncols=1)
         init[...] = False  # O(1) dense matrix in SuiteSparse 5
         step1 = semiring(v @ init).new()
-        index = step1[0].value
+        index = step1[0].new().value
         if index is None:
             index = 0
         if in_composite:
@@ -558,11 +558,11 @@ def _first_last(agg, updater, expr, *, in_composite, semiring):
         init2 = expr._new_vector(bool, size=A._nrows)
         init2[...] = False  # O(1) dense vector in SuiteSparse 5
         step2 = semiring(step1.T @ init2).new()
-        i = step2[0].value
+        i = step2[0].new().value
         if i is None:
             i = j = 0
         else:
-            j = step1[i, 0].value
+            j = step1[i, 0].new().value
         if in_composite:
             return A[i, [j]].new()
         updater << A[i, j]

--- a/grblas/_infixmethods.py
+++ b/grblas/_infixmethods.py
@@ -1,9 +1,9 @@
 from . import binary, unary
 from .dtypes import BOOL
 from .infix import MatrixInfixExpr, VectorInfixExpr
-from .matrix import Matrix, MatrixExpression, TransposedMatrix
+from .matrix import Matrix, MatrixExpression, MatrixIndexExpr, TransposedMatrix
 from .utils import output_type
-from .vector import Vector, VectorExpression
+from .vector import Vector, VectorExpression, VectorIndexExpr
 
 
 def call_op(self, other, method, op, *, outer=False, union=False):
@@ -262,6 +262,8 @@ for name in [
         setattr(MatrixExpression, name, val)
         setattr(VectorInfixExpr, name, val)
         setattr(MatrixInfixExpr, name, val)
+        setattr(VectorIndexExpr, name, val)
+        setattr(MatrixIndexExpr, name, val)
 # End auto-generated code
 
 if __name__ == "__main__":
@@ -350,6 +352,8 @@ if __name__ == "__main__":
         "        setattr(MatrixExpression, name, val)\n"
         "        setattr(VectorInfixExpr, name, val)\n"
         "        setattr(MatrixInfixExpr, name, val)\n"
+        "        setattr(VectorIndexExpr, name, val)\n"
+        "        setattr(MatrixIndexExpr, name, val)\n"
     )
     from .utils import _autogenerate_code
 

--- a/grblas/_ss/vector.py
+++ b/grblas/_ss/vector.py
@@ -9,13 +9,7 @@ from ..base import call
 from ..dtypes import _INDEX, INT64, UINT64, lookup_dtype
 from ..exceptions import check_status, check_status_carg
 from ..scalar import _as_scalar
-from ..utils import (
-    _CArray,
-    ints_to_numpy_buffer,
-    libget,
-    values_to_numpy_buffer,
-    wrapdoc,
-)
+from ..utils import _CArray, ints_to_numpy_buffer, libget, values_to_numpy_buffer, wrapdoc
 from .matrix import MatrixArray, _concat_mn, normalize_chunks
 from .prefix_scan import prefix_scan
 from .utils import get_order

--- a/grblas/base.py
+++ b/grblas/base.py
@@ -316,8 +316,8 @@ class BaseType:
     def _update(self, expr, mask=None, accum=None, replace=False, input_mask=None):
         # TODO: check expected output type (now included in Expression object)
         if not isinstance(expr, BaseExpression):
-            if type(expr) is AmbiguousAssignOrExtract:
-                if expr.resolved_indexes.is_single_element and self._is_scalar:
+            if isinstance(expr, AmbiguousAssignOrExtract):
+                if expr._is_scalar and self._is_scalar:
                     # Extract element (s << v[1])
                     if accum is not None:
                         raise TypeError(

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -7,6 +7,7 @@ from .base import BaseExpression, BaseType, call
 from .binary import isclose
 from .dtypes import _INDEX, BOOL, lookup_dtype
 from .exceptions import EmptyObject, check_status
+from .expr import AmbiguousAssignOrExtract
 from .operator import get_typed_op
 from .utils import _Pointer, output_type, wrapdoc
 
@@ -460,6 +461,53 @@ class ScalarExpression(BaseExpression):
     # End auto-generated code: Scalar
 
 
+class ScalarIndexExpr(AmbiguousAssignOrExtract):
+    output_type = Scalar
+    ndim = 0
+    shape = ()
+    _is_scalar = True
+
+    def new(self, dtype=None, *, is_cscalar=None, name=None):
+        if is_cscalar is None:
+            is_cscalar = False
+        return self.parent._extract_element(
+            self.resolved_indexes, dtype, is_cscalar=is_cscalar, name=name
+        )
+
+    # Begin auto-generated code: Scalar
+    _get_value = _automethods._get_value
+    __array__ = wrapdoc(Scalar.__array__)(property(_automethods.__array__))
+    __bool__ = wrapdoc(Scalar.__bool__)(property(_automethods.__bool__))
+    __complex__ = wrapdoc(Scalar.__complex__)(property(_automethods.__complex__))
+    __eq__ = wrapdoc(Scalar.__eq__)(property(_automethods.__eq__))
+    __float__ = wrapdoc(Scalar.__float__)(property(_automethods.__float__))
+    __index__ = wrapdoc(Scalar.__index__)(property(_automethods.__index__))
+    __int__ = wrapdoc(Scalar.__int__)(property(_automethods.__int__))
+    __invert__ = wrapdoc(Scalar.__invert__)(property(_automethods.__invert__))
+    __neg__ = wrapdoc(Scalar.__neg__)(property(_automethods.__neg__))
+    _is_empty = wrapdoc(Scalar._is_empty)(property(_automethods._is_empty))
+    _name_html = wrapdoc(Scalar._name_html)(property(_automethods._name_html))
+    _nvals = wrapdoc(Scalar._nvals)(property(_automethods._nvals))
+    gb_obj = wrapdoc(Scalar.gb_obj)(property(_automethods.gb_obj))
+    is_empty = wrapdoc(Scalar.is_empty)(property(_automethods.is_empty))
+    isclose = wrapdoc(Scalar.isclose)(property(_automethods.isclose))
+    isequal = wrapdoc(Scalar.isequal)(property(_automethods.isequal))
+    name = wrapdoc(Scalar.name)(property(_automethods.name))
+    name = name.setter(_automethods._set_name)
+    nvals = wrapdoc(Scalar.nvals)(property(_automethods.nvals))
+    to_pygraphblas = wrapdoc(Scalar.to_pygraphblas)(property(_automethods.to_pygraphblas))
+    value = wrapdoc(Scalar.value)(property(_automethods.value))
+    wait = wrapdoc(Scalar.wait)(property(_automethods.wait))
+    # These raise exceptions
+    __and__ = Scalar.__and__
+    __matmul__ = Scalar.__matmul__
+    __or__ = Scalar.__or__
+    __rand__ = Scalar.__rand__
+    __rmatmul__ = Scalar.__rmatmul__
+    __ror__ = Scalar.__ror__
+    # End auto-generated code: Scalar
+
+
 def _as_scalar(scalar, dtype=None, *, is_cscalar):
     if type(scalar) is not Scalar:
         return Scalar.from_value(scalar, dtype, is_cscalar=is_cscalar, name="")
@@ -472,4 +520,5 @@ def _as_scalar(scalar, dtype=None, *, is_cscalar):
 _MATERIALIZE = Scalar.from_value(lib.GrB_MATERIALIZE, is_cscalar=True, name="GrB_MATERIALIZE")
 
 utils._output_types[Scalar] = Scalar
+utils._output_types[ScalarIndexExpr] = Scalar
 utils._output_types[ScalarExpression] = Scalar

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -778,15 +778,15 @@ def test_div_semirings():
     A1 = Matrix.from_values([0, 1], [0, 0], [-1, -3])
     A2 = Matrix.from_values([0, 1], [0, 0], [2, 2])
     result = A1.T.mxm(A2, semiring.plus_cdiv).new()
-    assert result[0, 0].value == -1
+    assert result[0, 0].new() == -1
     assert result.dtype == dtypes.INT64
 
     result = A1.T.mxm(A2, semiring.plus_truediv).new()
-    assert result[0, 0].value == -2
+    assert result[0, 0].new() == -2
     assert result.dtype == dtypes.FP64
 
     result = A1.T.mxm(A2, semiring.plus_floordiv).new()
-    assert result[0, 0].value == -3
+    assert result[0, 0].new() == -3
     assert result.dtype == dtypes.INT64
 
 

--- a/grblas/tests/test_resolving.py
+++ b/grblas/tests/test_resolving.py
@@ -150,16 +150,16 @@ def test_updater_only_once():
         u[[0, 1]]()[0]
     with pytest.raises(TypeError, match="is not subscriptable"):
         u()[[0, 1]][0]
-    with pytest.raises(TypeError, match="is not subscriptable"):
+    with pytest.raises(TypeError, match="autocompute"):
         u[[0, 1]][0]
 
 
 def test_bad_extract_with_updater():
     u = Vector.from_values([0, 1, 3], [1, 2, 3])
-    assert u[0].value == 1
+    assert u[0].new() == 1
     with pytest.raises(AttributeError, match="'Assigner' object has no attribute 'value'"):
         u(mask=u.S)[0].value
-    with pytest.raises(AttributeError, match="Only Scalars"):
+    with pytest.raises(AttributeError, match="has no attribute"):
         u[[0, 1]].value
     with pytest.raises(AttributeError, match="'Assigner' object has no attribute 'new'"):
         u(mask=u.S)[0].new()
@@ -167,7 +167,7 @@ def test_bad_extract_with_updater():
         u << u(mask=u.S)[[1, 2]]
     with pytest.raises(TypeError, match="Assignment value must be a valid expression"):
         u << u()[[1, 2]]
-    with pytest.raises(TypeError, match="mask is not allowed for single element extraction"):
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
         u[0].new(mask=u.S)
     s = Scalar.from_value(10)
     with pytest.raises(TypeError, match="Indexing not supported for Scalars"):

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -49,7 +49,7 @@ def test_new():
 def test_large_vector():
     u = Vector.from_values([0, 2**59], [0, 1])
     assert u.size == 2**59 + 1
-    assert u[2**59].value == 1
+    assert u[2**59].new() == 1
     with pytest.raises(InvalidValue):
         Vector.from_values([0, 2**64 - 2], [0, 1])
     with pytest.raises(OverflowError):
@@ -64,7 +64,7 @@ def test_dup(v):
     assert u.size == v.size
     # Ensure they are not the same backend object
     v[0] = 1000
-    assert u[0].value != 1000
+    assert u[0].new() != 1000
     # extended functionality
     w = Vector.from_values([0, 1], [0, 2.5], dtype=dtypes.FP64)
     x = w.dup(dtype=dtypes.INT64)
@@ -88,7 +88,7 @@ def test_from_values():
     assert u3.size == 10
     assert u3.nvals == 2  # duplicates were combined
     assert u3.dtype == int
-    assert u3[1].value == 6  # 2*3
+    assert u3[1].new() == 6  # 2*3
     with pytest.raises(ValueError, match="Duplicate indices found"):
         # Duplicate indices requires a dup_op
         Vector.from_values([0, 1, 1], [True, True, True])
@@ -152,7 +152,7 @@ def test_resize(v):
     v.resize(20)
     assert v.size == 20
     assert v.nvals == 4
-    assert compute(v[19].value) is None
+    assert compute(v[19].new().value) is None
     v.resize(4)
     assert v.size == 4
     assert v.nvals == 2
@@ -231,7 +231,9 @@ def test_extract_input_mask():
 
 
 def test_extract_element(v):
-    assert v[1].value == 1
+    assert v[1].new() == 1
+    with pytest.raises(TypeError, match="enable automatic"):
+        v[1].value
     assert v[6].new() == 0
     with pytest.raises(TypeError, match="Invalid type for index"):
         v[object()]
@@ -243,19 +245,19 @@ def test_extract_element(v):
 
 
 def test_set_element(v):
-    assert compute(v[0].value) is None
-    assert v[1].value == 1
+    assert compute(v[0].new().value) is None
+    assert v[1].new() == 1
     v[0] = 12
     v[1] << 9
-    assert v[0].value == 12
+    assert v[0].new() == 12
     assert v[1].new() == 9
 
 
 def test_remove_element(v):
-    assert v[1].value == 1
+    assert v[1].new() == 1
     del v[1]
-    assert compute(v[1].value) is None
-    assert v[4].value == 2
+    assert compute(v[1].new().value) is None
+    assert v[4].new() == 2
     # with pytest.raises(TypeError, match="Remove Element only supports"):
     del v[1:3]  # Now okay
 
@@ -447,10 +449,10 @@ def test_extract_fancy_scalars(v):
 
 
 def test_extract_negative_indices(v):
-    assert v[-1].value == 0
-    assert compute(v[-v.size].value) is None
+    assert v[-1].new() == 0
+    assert compute(v[-v.size].new().value) is None
     assert v[[-v.size]].new().nvals == 0
-    assert v[Scalar.from_value(-4)].value == 1
+    assert v[Scalar.from_value(-4)].new() == 1
     w = v[[-1, -3]].new()
     assert w.isequal(Vector.from_values([0, 1], [0, 2]))
     with pytest.raises(IndexError):
@@ -1169,7 +1171,7 @@ def test_vector_index_with_scalar():
     expected = Vector.from_values([0, 1], [20, 10])
     for dtype in ["int8", "uint8", "int16", "uint16", "int32", "uint32"]:
         s1 = Scalar.from_value(1, dtype=dtype)
-        assert v[s1] == 20
+        assert v[s1].new() == 20
         s0 = Scalar.from_value(0, dtype=dtype)
         w = v[[s1, s0]].new()
         assert w.isequal(expected)
@@ -1318,9 +1320,10 @@ def test_auto_assign(v):
     expected[:3] = expr.new()
     v[:3] = expr
     assert expected.isequal(v)
-    with pytest.raises(TypeError):
-        # Not yet supported, but we could!
-        v[:3] = v[1:4]
+    v[:3] = v[1:4]
+    del expected[0]
+    expected[1] = 1
+    assert expected.isequal(v)
 
 
 @autocompute

--- a/grblas/utils.py
+++ b/grblas/utils.py
@@ -180,9 +180,19 @@ def _autogenerate_code(
         end = f"{end}: {specializer}"
     begin += "\n"
     end += "\n"
-    start = orig_text.index(begin)
-    stop = orig_text.index(end)
-    new_text = f"{orig_text[:start]}{begin}{text}{orig_text[stop:]}"
+
+    boundaries = []
+    stop = 0
+    while True:
+        try:
+            start = orig_text.index(begin, stop)
+            stop = orig_text.index(end, start)
+        except ValueError:
+            break
+        boundaries.append((start, stop))
+    new_text = orig_text
+    for start, stop in reversed(boundaries):
+        new_text = f"{new_text[:start]}{begin}{text}{new_text[stop:]}"
     with open(filename, "w") as f:
         f.write(new_text)
     import subprocess

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -115,14 +115,20 @@ class Vector(BaseType):
 
     def __getitem__(self, keys):
         resolved_indexes = IndexerResolver(self, keys)
-        return AmbiguousAssignOrExtract(self, resolved_indexes)
+        shape = resolved_indexes.shape
+        if not shape:
+            from .scalar import ScalarIndexExpr
+
+            return ScalarIndexExpr(self, resolved_indexes)
+        else:
+            return VectorIndexExpr(self, resolved_indexes, *shape)
 
     def __setitem__(self, keys, expr):
         Updater(self)[keys] = expr
 
     def __contains__(self, index):
         extractor = self[index]
-        if not extractor.resolved_indexes.is_single_element:
+        if not extractor._is_scalar:
             raise TypeError(
                 f"Invalid index to Vector contains: {index!r}.  An integer is expected.  "
                 "Doing `index in my_vector` checks whether a value is present at that index."
@@ -976,7 +982,76 @@ class VectorExpression(BaseExpression):
     # End auto-generated code: Vector
 
 
+class VectorIndexExpr(AmbiguousAssignOrExtract):
+    __slots__ = "_size"
+    ndim = 1
+    output_type = Vector
+
+    def __init__(self, parent, resolved_indexes, size):
+        super().__init__(parent, resolved_indexes)
+        self._size = size
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def shape(self):
+        return (self._size,)
+
+    # Begin auto-generated code: Vector
+    _get_value = _automethods._get_value
+    S = wrapdoc(Vector.S)(property(_automethods.S))
+    V = wrapdoc(Vector.V)(property(_automethods.V))
+    __and__ = wrapdoc(Vector.__and__)(property(_automethods.__and__))
+    __contains__ = wrapdoc(Vector.__contains__)(property(_automethods.__contains__))
+    __getitem__ = wrapdoc(Vector.__getitem__)(property(_automethods.__getitem__))
+    __iter__ = wrapdoc(Vector.__iter__)(property(_automethods.__iter__))
+    __matmul__ = wrapdoc(Vector.__matmul__)(property(_automethods.__matmul__))
+    __or__ = wrapdoc(Vector.__or__)(property(_automethods.__or__))
+    __rand__ = wrapdoc(Vector.__rand__)(property(_automethods.__rand__))
+    __rmatmul__ = wrapdoc(Vector.__rmatmul__)(property(_automethods.__rmatmul__))
+    __ror__ = wrapdoc(Vector.__ror__)(property(_automethods.__ror__))
+    _carg = wrapdoc(Vector._carg)(property(_automethods._carg))
+    _name_html = wrapdoc(Vector._name_html)(property(_automethods._name_html))
+    _nvals = wrapdoc(Vector._nvals)(property(_automethods._nvals))
+    apply = wrapdoc(Vector.apply)(property(_automethods.apply))
+    ewise_add = wrapdoc(Vector.ewise_add)(property(_automethods.ewise_add))
+    ewise_mult = wrapdoc(Vector.ewise_mult)(property(_automethods.ewise_mult))
+    ewise_union = wrapdoc(Vector.ewise_union)(property(_automethods.ewise_union))
+    gb_obj = wrapdoc(Vector.gb_obj)(property(_automethods.gb_obj))
+    inner = wrapdoc(Vector.inner)(property(_automethods.inner))
+    isclose = wrapdoc(Vector.isclose)(property(_automethods.isclose))
+    isequal = wrapdoc(Vector.isequal)(property(_automethods.isequal))
+    name = wrapdoc(Vector.name)(property(_automethods.name))
+    name = name.setter(_automethods._set_name)
+    nvals = wrapdoc(Vector.nvals)(property(_automethods.nvals))
+    outer = wrapdoc(Vector.outer)(property(_automethods.outer))
+    reduce = wrapdoc(Vector.reduce)(property(_automethods.reduce))
+    ss = wrapdoc(Vector.ss)(property(_automethods.ss))
+    to_pygraphblas = wrapdoc(Vector.to_pygraphblas)(property(_automethods.to_pygraphblas))
+    to_values = wrapdoc(Vector.to_values)(property(_automethods.to_values))
+    vxm = wrapdoc(Vector.vxm)(property(_automethods.vxm))
+    wait = wrapdoc(Vector.wait)(property(_automethods.wait))
+    # These raise exceptions
+    __array__ = Vector.__array__
+    __bool__ = Vector.__bool__
+    __iadd__ = _automethods.__iadd__
+    __iand__ = _automethods.__iand__
+    __ifloordiv__ = _automethods.__ifloordiv__
+    __imatmul__ = _automethods.__imatmul__
+    __imod__ = _automethods.__imod__
+    __imul__ = _automethods.__imul__
+    __ior__ = _automethods.__ior__
+    __ipow__ = _automethods.__ipow__
+    __isub__ = _automethods.__isub__
+    __itruediv__ = _automethods.__itruediv__
+    __ixor__ = _automethods.__ixor__
+    # End auto-generated code: Vector
+
+
 utils._output_types[Vector] = Vector
+utils._output_types[VectorIndexExpr] = Vector
 utils._output_types[VectorExpression] = Vector
 
 # Import matrix to import infix to import _infixmethods, which has side effects

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ skip_gitignore = true
 float_to_top = true
 default_section = THIRDPARTY
 known_first_party = grblas
+line_length = 100
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
Fixes #149

This adds new classes such as `MatrixIndexExpr`, which are able to be auto-computed.  PR #157 made this relatively easy.  I still need to add a few tests.