### PR TITLE
Add `gb.agg.from_string`

### DIFF
--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -734,7 +734,7 @@ class Matrix(BaseType):
         Default op is monoid.lor for boolean and monoid.plus otherwise
         """
         method_name = "reduce_rowwise"
-        op = get_typed_op(op, self.dtype, kind="binary")
+        op = get_typed_op(op, self.dtype, kind="binary|aggregator")
         self._expect_op(op, ("BinaryOp", "Monoid", "Aggregator"), within=method_name, argname="op")
         # Using a monoid may be more efficient, so change to one if possible.
         # Also, SuiteSparse doesn't like user-defined binarops here.
@@ -770,7 +770,7 @@ class Matrix(BaseType):
         Default op is monoid.lor for boolean and monoid.plus otherwise
         """
         method_name = "reduce_columnwise"
-        op = get_typed_op(op, self.dtype, kind="binary")
+        op = get_typed_op(op, self.dtype, kind="binary|aggregator")
         self._expect_op(op, ("BinaryOp", "Monoid", "Aggregator"), within=method_name, argname="op")
         # Using a monoid may be more efficient, so change to one if possible.
         # Also, SuiteSparse doesn't like user-defined binarops here.
@@ -809,7 +809,7 @@ class Matrix(BaseType):
         `allow_empty` is False or empty Scalar if `allow_empty` is True.
         """
         method_name = "reduce_scalar"
-        op = get_typed_op(op, self.dtype, kind="binary")
+        op = get_typed_op(op, self.dtype, kind="binary|aggregator")
         if op.opclass == "BinaryOp" and op.monoid is not None:
             op = op.monoid
         else:

--- a/grblas/tests/conftest.py
+++ b/grblas/tests/conftest.py
@@ -11,18 +11,18 @@ import grblas as gb
 def pytest_configure(config):
     randomly = config.getoption("--randomly", False)
     backend = config.getoption("--backend", "suitesparse")
-    blocking = config.getoption("--blocking", None if randomly else True)
+    blocking = config.getoption("--blocking", True)
     if blocking is None:
-        blocking = np.random.rand() < 0.5
-    record = config.getoption("--record", None if randomly else False)
+        blocking = np.random.rand() < 0.5 if randomly else True
+    record = config.getoption("--record", False)
     if record is None:
-        record = np.random.rand() < 0.5
-    mapnumpy = config.getoption("--mapnumpy", None if randomly else True)
+        record = np.random.rand() < 0.5 if randomly else False
+    mapnumpy = config.getoption("--mapnumpy", True)
     if mapnumpy is None:
-        mapnumpy = np.random.rand() < 0.5
-    runslow = config.getoption("--runslow", None if randomly else True)
+        mapnumpy = np.random.rand() < 0.5 if randomly else True
+    runslow = config.getoption("--runslow", False)
     if runslow is None:
-        runslow = np.random.rand() < 0.5
+        runslow = np.random.rand() < 0.5 if randomly else False
     config.runslow = runslow
 
     gb.config.set(autocompute=False, mapnumpy=mapnumpy)

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -103,6 +103,14 @@ def test_get_typed_op():
     assert operator.get_typed_op("+.*", dtypes.FP64, kind="semiring") is semiring.plus_times["FP64"]
     with pytest.raises(ValueError, match="Unable to get op from string"):
         operator.get_typed_op("+", dtypes.FP64)
+    assert (
+        operator.get_typed_op("+", dtypes.INT64, kind="binary|aggregator") is binary.plus["INT64"]
+    )
+    assert (
+        operator.get_typed_op("count", dtypes.INT64, kind="binary|aggregator") is agg.count["INT64"]
+    )
+    with pytest.raises(ValueError, match="Bad binary or aggregator"):
+        operator.get_typed_op("bad_op_name", dtypes.INT64, kind="binary|aggregator")
 
 
 def test_unaryop_udf():
@@ -937,6 +945,12 @@ def test_from_string():
     assert op.from_string("min.plus") is semiring.min_plus
     with pytest.raises(ValueError, match="Unknown op string"):
         op.from_string("min.plus.times")
+
+    assert agg.from_string("count") is agg.count
+    assert agg.from_string("|") is agg.any
+    assert agg.from_string("+[int]") is agg.sum[int]
+    with pytest.raises(ValueError, match="Unknown agg string"):
+        agg.from_string("bad_agg")
 
 
 def test_lazy_op():

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -637,7 +637,7 @@ class Vector(BaseType):
         `allow_empty` is False or empty Scalar if `allow_empty` is True.
         """
         method_name = "reduce"
-        op = get_typed_op(op, self.dtype, kind="binary")
+        op = get_typed_op(op, self.dtype, kind="binary|aggregator")
         if op.opclass == "BinaryOp" and op.monoid is not None:
             op = op.monoid
         else:


### PR DESCRIPTION
I just noticed this was missing.  This also enables this: `A.reduce_rowwise("count")`.

Also, friendly reminder that `grblas.op` does not contain aggregators.  I think this is okay.