### PR TITLE
Add `rpow` and improve tab-completion of operator namespaces.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,6 @@ def pytest_addoption(parser):
         help="Record GraphBLAS C calls and save to 'record.txt'",
     )
     parser.addoption(
-        "--mapnumpy", action="store_true", default=None, help="may numpy ops to GraphBLAS ops"
+        "--mapnumpy", action="store_true", default=None, help="map numpy ops to GraphBLAS ops"
     )
     parser.addoption("--randomly", action="store_true", help="run random test config")

--- a/grblas/binary/__init__.py
+++ b/grblas/binary/__init__.py
@@ -6,11 +6,23 @@ _delayed_commutes_to = {
     "abssecond": "absfirst",
     "floordiv": "rfloordiv",
     "rfloordiv": "floordiv",
+    "rpow": "pow",
 }
 from grblas import operator  # noqa isort:skip
 from . import numpy  # noqa isort:skip
 
 del operator
+
+
+def __dir__():
+    from grblas.operator import BinaryOp, ParameterizedBinaryOp
+
+    keys = set(_delayed)
+    keys.add("numpy")
+    keys.update(
+        key for key, val in globals().items() if isinstance(val, (BinaryOp, ParameterizedBinaryOp))
+    )
+    return keys
 
 
 def __getattr__(key):

--- a/grblas/binary/__init__.py
+++ b/grblas/binary/__init__.py
@@ -15,14 +15,7 @@ del operator
 
 
 def __dir__():
-    from grblas.operator import BinaryOp, ParameterizedBinaryOp
-
-    keys = set(_delayed)
-    keys.add("numpy")
-    keys.update(
-        key for key, val in globals().items() if isinstance(val, (BinaryOp, ParameterizedBinaryOp))
-    )
-    return keys
+    return globals().keys() | _delayed.keys()
 
 
 def __getattr__(key):

--- a/grblas/binary/__init__.py
+++ b/grblas/binary/__init__.py
@@ -35,7 +35,7 @@ def __getattr__(key):
             if other_key in globals():
                 other = globals()[other_key]
             else:
-                other = __getattr__(other_key)
-            rv.commutes_to = other
+                other = other_key
+            rv._commutes_to = other
         return rv
     raise AttributeError(f"module {__name__!r} has no attribute {key!r}")

--- a/grblas/binary/numpy.py
+++ b/grblas/binary/numpy.py
@@ -125,7 +125,7 @@ _commutes_to = {
 
 
 def __dir__():
-    return __all__ + list(_delayed)
+    return globals().keys() | _delayed.keys() | _binary_names
 
 
 def __getattr__(name):

--- a/grblas/binary/numpy.py
+++ b/grblas/binary/numpy.py
@@ -143,9 +143,7 @@ def __getattr__(name):
         _operator.BinaryOp.register_new(f"numpy.{name}", lambda x, y: numpy_func(x, y))
     rv = globals()[name]
     if name in _commutative:
-        rv.commutes_to = rv
-    elif name in _commutes_to:
-        right = getattr(_binary.numpy, _commutes_to[name])
-        rv.commutes_to = rv.commutes_to or right
-        right.commutes_to = right.commutes_to or rv
+        rv._commutes_to = rv
+    elif name in _commutes_to and rv._commutes_to is None:
+        rv._commutes_to = f"numpy.{_commutes_to[name]}"
     return rv

--- a/grblas/monoid/__init__.py
+++ b/grblas/monoid/__init__.py
@@ -7,6 +7,17 @@ from . import numpy  # noqa isort:skip
 del operator
 
 
+def __dir__():
+    from grblas.operator import Monoid, ParameterizedMonoid
+
+    keys = set(_delayed)
+    keys.add("numpy")
+    keys.update(
+        key for key, val in globals().items() if isinstance(val, (Monoid, ParameterizedMonoid))
+    )
+    return keys
+
+
 def __getattr__(key):
     if key in _delayed:
         func, kwargs = _delayed.pop(key)

--- a/grblas/monoid/__init__.py
+++ b/grblas/monoid/__init__.py
@@ -8,14 +8,7 @@ del operator
 
 
 def __dir__():
-    from grblas.operator import Monoid, ParameterizedMonoid
-
-    keys = set(_delayed)
-    keys.add("numpy")
-    keys.update(
-        key for key, val in globals().items() if isinstance(val, (Monoid, ParameterizedMonoid))
-    )
-    return keys
+    return globals().keys() | _delayed.keys()
 
 
 def __getattr__(key):

--- a/grblas/monoid/numpy.py
+++ b/grblas/monoid/numpy.py
@@ -117,7 +117,7 @@ _numpy_to_graphblas = {
 
 
 def __dir__():
-    return __all__ + list(_delayed)
+    return globals().keys() | _delayed.keys() | _monoid_identities.keys()
 
 
 def __getattr__(name):

--- a/grblas/op/__init__.py
+++ b/grblas/op/__init__.py
@@ -8,14 +8,7 @@ del operator
 
 
 def __dir__():
-    from grblas.operator import OpBase, ParameterizedUdf
-
-    keys = set(_delayed)
-    keys.add("numpy")
-    keys.update(
-        key for key, val in globals().items() if isinstance(val, (OpBase, ParameterizedUdf))
-    )
-    return keys
+    return globals().keys() | _delayed.keys()
 
 
 def __getattr__(key):

--- a/grblas/op/__init__.py
+++ b/grblas/op/__init__.py
@@ -7,6 +7,17 @@ from . import numpy  # noqa isort:skip
 del operator
 
 
+def __dir__():
+    from grblas.operator import OpBase, ParameterizedUdf
+
+    keys = set(_delayed)
+    keys.add("numpy")
+    keys.update(
+        key for key, val in globals().items() if isinstance(val, (OpBase, ParameterizedUdf))
+    )
+    return keys
+
+
 def __getattr__(key):
     if key in _delayed:
         module = _delayed.pop(key)

--- a/grblas/op/numpy.py
+++ b/grblas/op/numpy.py
@@ -10,7 +10,7 @@ __all__ = list(_op_to_mod)
 
 
 def __dir__():
-    return __all__ + list(_delayed)
+    return globals().keys() | _delayed.keys() | _op_to_mod.keys()
 
 
 def __getattr__(name):

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -356,7 +356,7 @@ class ParameterizedUnaryOp(ParameterizedUdf):
 
 
 class ParameterizedBinaryOp(ParameterizedUdf):
-    __slots__ = "func", "__signature__", "_monoid", "_cached_call", "commutes_to"
+    __slots__ = "func", "__signature__", "_monoid", "_cached_call", "_commutes_to"
 
     def __init__(self, name, func, *, anonymous=False):
         self.func = func
@@ -368,7 +368,7 @@ class ParameterizedBinaryOp(ParameterizedUdf):
         method = self._call_to_cache.__get__(self, type(self))
         self._cached_call = lru_cache(maxsize=1024)(method)
         self.__call__ = self._call
-        self.commutes_to = None
+        self._commutes_to = None
 
     def _call_to_cache(self, *args, **kwargs):
         binary = self.func(*args, **kwargs)
@@ -389,13 +389,19 @@ class ParameterizedBinaryOp(ParameterizedUdf):
                 binop._monoid = None
             assert binop._monoid is not binop
         if self.is_commutative:
-            binop.commutes_to = binop
+            binop._commutes_to = binop
         # Don't bother yet with creating `binop.commutes_to` (but we could!)
         return binop
 
     @property
     def monoid(self):
         return self._monoid
+
+    @property
+    def commutes_to(self):
+        if type(self._commutes_to) is str:
+            self._commutes_to = BinaryOp._find(self._commutes_to)
+        return self._commutes_to
 
     is_commutative = TypedBuiltinBinaryOp.is_commutative
 
@@ -916,7 +922,7 @@ def _isclose(rel_tol=1e-7, abs_tol=0.0):
 
 
 class BinaryOp(OpBase):
-    __slots__ = "_monoid", "commutes_to", "_semiring_commutes_to", "_func", "is_positional"
+    __slots__ = "_monoid", "_commutes_to", "_semiring_commutes_to", "_func", "is_positional"
     _module = binary
     _modname = "binary"
     _typed_class = TypedBuiltinBinaryOp
@@ -958,7 +964,7 @@ class BinaryOp(OpBase):
         ],
         "re_exprs_return_complex": [re.compile("^GxB_(CMPLX)_(FP32|FP64)$")],
     }
-    _commutes_to = {
+    _commutes = {
         # builtins
         "cdiv": "rdiv",
         "first": "second",
@@ -1191,7 +1197,7 @@ class BinaryOp(OpBase):
         # For aggregators
         BinaryOp.register_new("absfirst", _absfirst, lazy=True)
         BinaryOp.register_new("abssecond", _abssecond, lazy=True)
-        BinaryOp.register_new("rpow", _rpow)
+        BinaryOp.register_new("rpow", _rpow, lazy=True)
 
         BinaryOp.register_new("isclose", _isclose, parameterized=True)
 
@@ -1252,14 +1258,15 @@ class BinaryOp(OpBase):
         del binary.ldexp["FP32"]
         del binary.ldexp["FP64"]
         # Fill in commutes info
-        for left, right in cls._commutes_to.items():
-            left = getattr(binary, left)
-            right = getattr(binary, right)
-            left.commutes_to = right
-            right.commutes_to = left
-        for cur_op in cls._commutative:
-            cur_op = getattr(binary, cur_op)
-            cur_op.commutes_to = cur_op
+        for left_name, right_name in cls._commutes.items():
+            left = getattr(binary, left_name)
+            left._commutes_to = right_name
+            if right_name not in binary._delayed:
+                right = getattr(binary, right_name)
+                right._commutes_to = left_name
+        for name in cls._commutative:
+            cur_op = getattr(binary, name)
+            cur_op._commutes_to = name
         for left, right in cls._commutes_to_in_semiring.items():
             left = getattr(binary, left)
             right = getattr(binary, right)
@@ -1270,7 +1277,7 @@ class BinaryOp(OpBase):
     def __init__(self, name, func=None, *, anonymous=False, is_positional=False):
         super().__init__(name, anonymous=anonymous)
         self._monoid = None
-        self.commutes_to = None
+        self._commutes_to = None
         self._semiring_commutes_to = None
         self._func = func
         self.is_positional = is_positional
@@ -1287,6 +1294,7 @@ class BinaryOp(OpBase):
 
     __call__ = TypedBuiltinBinaryOp.__call__
     is_commutative = TypedBuiltinBinaryOp.is_commutative
+    commutes_to = ParameterizedBinaryOp.commutes_to
 
     @property
     def monoid(self):
@@ -1593,8 +1601,8 @@ class Semiring(OpBase):
                 cdiv_semiring._add(new_semiring)
         # Also add truediv (always floating point) and floordiv (truncate towards -inf)
         for orig_name, orig in div_semirings.items():
-            cls.register_new(f"{orig_name[:-3]}truediv", orig.monoid, binary.truediv)
-            cls.register_new(f"{orig_name[:-3]}rtruediv", orig.monoid, binary.rtruediv)
+            cls.register_new(f"{orig_name[:-3]}truediv", orig.monoid, binary.truediv, lazy=True)
+            cls.register_new(f"{orig_name[:-3]}rtruediv", orig.monoid, "rtruediv", lazy=True)
             cls.register_new(f"{orig_name[:-3]}floordiv", orig.monoid, "floordiv", lazy=True)
             cls.register_new(f"{orig_name[:-3]}rfloordiv", orig.monoid, "rfloordiv", lazy=True)
         # For aggregators

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -904,6 +904,10 @@ def _abssecond(x, y):
     return abs(y)
 
 
+def _rpow(x, y):
+    return y**x
+
+
 def _isclose(rel_tol=1e-7, abs_tol=0.0):
     def inner(x, y):
         return x == y or abs(x - y) <= max(rel_tol * max(abs(x), abs(y)), abs_tol)
@@ -963,6 +967,7 @@ class BinaryOp(OpBase):
         "isge": "isle",
         "isgt": "islt",
         "minus": "rminus",
+        "pow": "rpow",
         # special
         "firsti": "secondi",
         "firsti1": "secondi1",
@@ -1003,7 +1008,7 @@ class BinaryOp(OpBase):
         "ne",
         "pair",
     }
-    # Don't commute: atan2, bclr, bget, bset, bshift, cmplx, copysign, fmod, ldexp, pow, remainder
+    # Don't commute: atan2, bclr, bget, bset, bshift, cmplx, copysign, fmod, ldexp, remainder
     _positional = {
         "firsti",
         "firsti1",
@@ -1186,6 +1191,7 @@ class BinaryOp(OpBase):
         # For aggregators
         BinaryOp.register_new("absfirst", _absfirst, lazy=True)
         BinaryOp.register_new("abssecond", _abssecond, lazy=True)
+        BinaryOp.register_new("rpow", _rpow)
 
         BinaryOp.register_new("isclose", _isclose, parameterized=True)
 
@@ -1588,11 +1594,16 @@ class Semiring(OpBase):
         # Also add truediv (always floating point) and floordiv (truncate towards -inf)
         for orig_name, orig in div_semirings.items():
             cls.register_new(f"{orig_name[:-3]}truediv", orig.monoid, binary.truediv)
+            cls.register_new(f"{orig_name[:-3]}rtruediv", orig.monoid, binary.rtruediv)
             cls.register_new(f"{orig_name[:-3]}floordiv", orig.monoid, "floordiv", lazy=True)
+            cls.register_new(f"{orig_name[:-3]}rfloordiv", orig.monoid, "rfloordiv", lazy=True)
         # For aggregators
         cls.register_new("plus_pow", monoid.plus, binary.pow)
+        cls.register_new("plus_rpow", monoid.plus, "rpow", lazy=True)
         cls.register_new("plus_absfirst", monoid.plus, "absfirst", lazy=True)
         cls.register_new("max_absfirst", monoid.max, "absfirst", lazy=True)
+        cls.register_new("plus_abssecond", monoid.plus, "abssecond", lazy=True)
+        cls.register_new("max_abssecond", monoid.max, "abssecond", lazy=True)
 
         # Update type information with sane coercion
         for lname in ("any", "eq", "land", "lor", "lxnor", "lxor"):

--- a/grblas/semiring/__init__.py
+++ b/grblas/semiring/__init__.py
@@ -8,14 +8,7 @@ del operator
 
 
 def __dir__():
-    from grblas.operator import ParameterizedSemiring, Semiring
-
-    keys = set(_delayed)
-    keys.add("numpy")
-    keys.update(
-        key for key, val in globals().items() if isinstance(val, (Semiring, ParameterizedSemiring))
-    )
-    return keys
+    return globals().keys() | _delayed.keys()
 
 
 def __getattr__(key):

--- a/grblas/semiring/__init__.py
+++ b/grblas/semiring/__init__.py
@@ -7,6 +7,17 @@ from . import numpy  # noqa isort:skip
 del operator
 
 
+def __dir__():
+    from grblas.operator import ParameterizedSemiring, Semiring
+
+    keys = set(_delayed)
+    keys.add("numpy")
+    keys.update(
+        key for key, val in globals().items() if isinstance(val, (Semiring, ParameterizedSemiring))
+    )
+    return keys
+
+
 def __getattr__(key):
     if key in _delayed:
         func, kwargs = _delayed.pop(key)

--- a/grblas/semiring/numpy.py
+++ b/grblas/semiring/numpy.py
@@ -88,7 +88,7 @@ __all__ = list(_semiring_names)
 
 
 def __dir__():
-    return __all__ + list(_delayed)
+    return globals().keys() | _delayed.keys() | _semiring_names
 
 
 def __getattr__(name):

--- a/grblas/tests/conftest.py
+++ b/grblas/tests/conftest.py
@@ -7,6 +7,9 @@ import pytest
 
 import grblas as gb
 
+orig_binaryops = set()
+orig_semirings = set()
+
 
 def pytest_configure(config):
     randomly = config.getoption("--randomly", False)
@@ -42,6 +45,20 @@ def pytest_configure(config):
 
         # I'm sure there's a `pytest` way to do this...
         atexit.register(save_records)
+    orig_semirings.update(
+        key
+        for key in dir(gb.semiring)
+        if isinstance(
+            getattr(gb.semiring, key), (gb.operator.Semiring, gb.operator.ParameterizedSemiring)
+        )
+    )
+    orig_binaryops.update(
+        key
+        for key in dir(gb.binary)
+        if isinstance(
+            getattr(gb.binary, key), (gb.operator.BinaryOp, gb.operator.ParameterizedBinaryOp)
+        )
+    )
     for mod in [gb.unary, gb.binary, gb.monoid, gb.semiring, gb.op]:
         for name in list(mod._delayed):
             getattr(mod, name)

--- a/grblas/tests/conftest.py
+++ b/grblas/tests/conftest.py
@@ -20,9 +20,9 @@ def pytest_configure(config):
     record = config.getoption("--record", False)
     if record is None:
         record = np.random.rand() < 0.5 if randomly else False
-    mapnumpy = config.getoption("--mapnumpy", True)
+    mapnumpy = config.getoption("--mapnumpy", False)
     if mapnumpy is None:
-        mapnumpy = np.random.rand() < 0.5 if randomly else True
+        mapnumpy = np.random.rand() < 0.5 if randomly else False
     runslow = config.getoption("--runslow", False)
     if runslow is None:
         runslow = np.random.rand() < 0.5 if randomly else False

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -778,7 +778,8 @@ def test_binaryop_superset_monoids():
     binary_names = {x for x in dir(binary) if not x.startswith("_")}
     diff = monoid_names - binary_names
     assert not diff
-    assert not set(dir(monoid.numpy)) - set(dir(binary.numpy))
+    extras = {x for x in set(dir(monoid.numpy)) - set(dir(binary.numpy)) if not x.startswith("_")}
+    assert not extras, ", ".join(sorted(extras))
 
 
 def test_div_semirings():

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -865,7 +865,7 @@ def test_commutes():
     assert semiring.any_first.commutes_to is semiring.any_second
     assert semiring.plus_times.is_commutative
     assert semiring.min_secondi.commutes_to is semiring.min_firstj
-    assert semiring.plus_pow.commutes_to is None
+    assert semiring.plus_pow.commutes_to is semiring.plus_rpow
     assert not semiring.plus_pow.is_commutative
     assert binary.isclose.commutes_to is binary.isclose
     assert binary.isclose.is_commutative
@@ -891,7 +891,7 @@ def test_commutes():
     assert semiring.any_first[int].commutes_to is semiring.any_second[int]
     assert semiring.plus_times[int].is_commutative
     assert semiring.min_secondi[int].commutes_to is semiring.min_firstj[int]
-    assert semiring.plus_pow[int].commutes_to is None
+    assert semiring.plus_pow[int].commutes_to is semiring.plus_rpow[int]
     assert not semiring.plus_pow[int].is_commutative
     assert binary.isclose(0.1)[int].commutes_to is binary.isclose(0.1)[int]
     assert binary.floordiv[int].commutes_to is binary.rfloordiv[int]
@@ -953,6 +953,7 @@ def test_from_string():
         agg.from_string("bad_agg")
 
 
+@pytest.mark.slow
 def test_lazy_op():
     UnaryOp.register_new("lazy", lambda x: x, lazy=True)
     assert isinstance(op.lazy, UnaryOp)
@@ -1014,3 +1015,36 @@ def test_positional():
     assert semiring.any_secondj[int].is_positional
     assert not semiring.any_first.is_positional
     assert not semiring.any_second[int].is_positional
+
+
+def test_dir():
+    for mod in [unary, binary, monoid, semiring, op]:
+        assert not set(mod._delayed) - set(dir(mod))
+
+
+def test_semiring_commute_exists():
+    from .conftest import orig_semirings
+
+    vals = {getattr(semiring, key) for key in orig_semirings}
+    missing = set()
+    for key in orig_semirings:
+        val = getattr(semiring, key)
+        commutes_to = val.commutes_to
+        if commutes_to is not None and commutes_to not in vals:
+            missing.add(commutes_to.name)
+    if missing:
+        raise AssertionError("Missing semirings: " + ", ".join(sorted(missing)))
+
+
+def test_binaryop_commute_exists():
+    from .conftest import orig_binaryops
+
+    vals = {getattr(binary, key) for key in orig_binaryops}
+    missing = set()
+    for key in orig_binaryops:
+        val = getattr(binary, key)
+        commutes_to = val.commutes_to
+        if commutes_to is not None and commutes_to not in vals:
+            missing.add(commutes_to.name)
+    if missing:
+        raise AssertionError("Missing binaryops: " + ", ".join(sorted(missing)))

--- a/grblas/tests/test_op.py
+++ b/grblas/tests/test_op.py
@@ -1030,7 +1030,7 @@ def test_semiring_commute_exists():
     for key in orig_semirings:
         val = getattr(semiring, key)
         commutes_to = val.commutes_to
-        if commutes_to is not None and commutes_to not in vals:
+        if commutes_to is not None and commutes_to not in vals:  # pragma: no cover
             missing.add(commutes_to.name)
     if missing:
         raise AssertionError("Missing semirings: " + ", ".join(sorted(missing)))
@@ -1044,7 +1044,7 @@ def test_binaryop_commute_exists():
     for key in orig_binaryops:
         val = getattr(binary, key)
         commutes_to = val.commutes_to
-        if commutes_to is not None and commutes_to not in vals:
+        if commutes_to is not None and commutes_to not in vals:  # pragma: no cover
             missing.add(commutes_to.name)
     if missing:
         raise AssertionError("Missing binaryops: " + ", ".join(sorted(missing)))

--- a/grblas/unary/__init__.py
+++ b/grblas/unary/__init__.py
@@ -7,6 +7,17 @@ from . import numpy  # noqa isort:skip
 del operator
 
 
+def __dir__():
+    from grblas.operator import ParameterizedUnaryOp, UnaryOp
+
+    keys = set(_delayed)
+    keys.add("numpy")
+    keys.update(
+        key for key, val in globals().items() if isinstance(val, (UnaryOp, ParameterizedUnaryOp))
+    )
+    return keys
+
+
 def __getattr__(key):
     if key in _delayed:
         func, kwargs = _delayed.pop(key)

--- a/grblas/unary/__init__.py
+++ b/grblas/unary/__init__.py
@@ -8,14 +8,7 @@ del operator
 
 
 def __dir__():
-    from grblas.operator import ParameterizedUnaryOp, UnaryOp
-
-    keys = set(_delayed)
-    keys.add("numpy")
-    keys.update(
-        key for key, val in globals().items() if isinstance(val, (UnaryOp, ParameterizedUnaryOp))
-    )
-    return keys
+    return globals().keys() | _delayed.keys()
 
 
 def __getattr__(key):

--- a/grblas/unary/numpy.py
+++ b/grblas/unary/numpy.py
@@ -112,7 +112,7 @@ __all__ = list(_unary_names)
 
 
 def __dir__():
-    return __all__ + list(_delayed)
+    return globals().keys() | _delayed.keys() | _unary_names
 
 
 def __getattr__(name):


### PR DESCRIPTION
Also, make sure all commute targets exists (but haven't done this for numpy namespaces yet)