### PR TITLE
Autocompute scalar expressions in `.update` if valid.

### DIFF
--- a/grblas/base.py
+++ b/grblas/base.py
@@ -420,6 +420,16 @@ class BaseType:
                         updater[...] = scalar
                     return
 
+        if type(self) is not expr.output_type:
+            if expr.output_type._is_scalar and config.get("autocompute"):
+                self._update(expr._get_value(), mask, accum, replace, input_mask)
+                return
+            from .scalar import Scalar
+
+            valid = (Scalar, type(self), type(type(self).__name__ + "Expression", (), {}))
+            valid = valid[1:] if self._is_scalar else valid
+            self._expect_type(expr, valid, within="update")
+
         if input_mask is not None:
             raise TypeError("`input_mask` argument may only be used for extract")
         if expr.op is not None and expr.op.opclass == "Aggregator":

--- a/grblas/tests/test_infix.py
+++ b/grblas/tests/test_infix.py
@@ -207,7 +207,7 @@ def test_bad_matmul(s1, v1, A1, A2):
     w = v1[:1].new()
     with raises(DimensionMismatch):
         w @ v1
-    with raises(DimensionMismatch):
+    with raises(TypeError):
         v1 @= v1
 
     with raises(TypeError, match="Bad type when calling semiring.plus_times"):

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1225,6 +1225,10 @@ def test_inner(v):
     assert s == 6
     s(binary.plus) << v.inner(v)
     assert s == 12
+    with pytest.raises(TypeError, match="autocompute"):
+        v << v.inner(v)
+    with pytest.raises(TypeError, match="autocompute"):
+        v(v.S) << v.inner(v)
 
 
 @autocompute
@@ -1234,6 +1238,20 @@ def test_inner_infix(v):
     assert s == 6
     s(binary.plus) << v @ v
     assert s == 12
+    # These autocompute to a scalar on the right!
+    v << v @ v
+    expected = Vector.new(v.dtype, v.size)
+    expected[:] = 6
+    assert v.isequal(expected)
+    v(v.S) << v @ v
+    expected[:] = 6 * 6 * 7
+    assert v.isequal(expected)
+    v[:] = 6
+    v << v.inner(v)
+    assert v.isequal(expected)
+    v[:] = 6
+    v[:] = v @ v
+    assert v.isequal(expected)
 
 
 def test_outer(v):


### PR DESCRIPTION
This was an interesting edge case that I stumbled upon!
Anyway, I think this can also provide better error messages.