### PR TITLE
Make `v += expr` do `v(plus) << expr` when expr is not scalar.

### DIFF
--- a/grblas/base.py
+++ b/grblas/base.py
@@ -65,7 +65,7 @@ def _expect_type_message(
         elif output_type(x) in types:
             if config.get("autocompute"):
                 return x._get_value(), None
-            extra_message = extra_message or f"{extra_message}\n\n"
+            extra_message = f"{extra_message}\n\n" if extra_message else ""
             extra_message += (
                 "Hint: use `grblas.config.set(autocompute=True)` to automatically "
                 "compute arguments that are expressions."
@@ -75,7 +75,7 @@ def _expect_type_message(
     elif output_type(x) is types:
         if config.get("autocompute"):
             return x._get_value(), None
-        extra_message = extra_message or f"{extra_message}\n\n"
+        extra_message = f"{extra_message}\n\n" if extra_message else ""
         extra_message += (
             "Hint: use `grblas.config.set(autocompute=True)` to automatically "
             "compute arguments that are expressions."

--- a/grblas/scalar.py
+++ b/grblas/scalar.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 
-from . import _automethods, backend, ffi, lib, utils
+from . import _automethods, backend, config, ffi, lib, utils
 from .base import BaseExpression, BaseType, call
 from .binary import isclose
 from .dtypes import _INDEX, BOOL, lookup_dtype
@@ -336,7 +336,15 @@ class Scalar(BaseType):
                         f"Argument of from_value must be a known scalar type, not {type(value)}"
                     ) from None
         if typ is Scalar and type(value) is not Scalar:
-            return value.new(dtype=dtype, is_cscalar=is_cscalar, name=name)
+            if config.get("autocompute"):
+                return value.new(dtype=dtype, is_cscalar=is_cscalar, name=name)
+            cls._expect_type(
+                value,
+                Scalar,
+                within="from_value",
+                argname="value",
+                extra_message="Literal scalars expected.",
+            )
         new_scalar = cls.new(dtype, is_cscalar=is_cscalar, name=name)
         new_scalar.value = value
         return new_scalar

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1685,3 +1685,28 @@ def test_delete_via_scalar(v):
     assert v.isequal(Vector.from_values([4, 6], [2, 0]))
     del v[:]
     assert v.nvals == 0
+
+
+def test_infix_outer():
+    v = Vector.new(int, 2)
+    v += 1
+    assert v.nvals == 0
+    v[:] = 1
+    v += 1
+    assert v.reduce().new() == 4
+    v += v
+    assert v.reduce().new() == 8
+    v += v + v
+    assert v.reduce().new() == 24
+    with pytest.raises(TypeError, match="autocompute"):
+        v += v @ v
+    with pytest.raises(TypeError, match="only supported for BOOL"):
+        v ^= v
+    with pytest.raises(TypeError, match="only supported for BOOL"):
+        v |= True
+    w = Vector.new(bool, 2)
+    w |= True
+    assert w.nvals == 0
+    w[:] = False
+    w |= True
+    assert w.reduce(binary.plus[int]).new() == 2


### PR DESCRIPTION
This allows `+=` (or any inplace infix that performs outer join) to operate in one C call instead of two.

Pragmatically, this helps one from debating over `x += expr` and `x(plus) << expr`, which now produce the exact same C calls.  This also keeps the original behavior with scalars: `x += 1` is the same as `x << x + 1`,  which only adds 1 to existing entries--it does not "densify" the object.

The only "visible" change for users is that e.g. `x += x + x` will now compute when autocompute is disabled.

Heh, as you probably guessed, this came about b/c I was fretting over `x += expr` and `x(plus) << expr`.  @jim22k which do you consider more idiomatic?  I think I generally prefer `x += expr`.