### PR TITLE
Add `x.ss.iso_value` to Vector and Matrix objects

### DIFF
--- a/grblas/_ss/matrix.py
+++ b/grblas/_ss/matrix.py
@@ -352,6 +352,12 @@ class ss:
         return is_iso[0]
 
     @property
+    def iso_value(self):
+        if self.is_iso:
+            return self._parent.reduce_scalar(monoid.any).new(name="")
+        raise ValueError("Matrix is not iso-valued")
+
+    @property
     def format(self):
         # Determine current format
         parent = self._parent

--- a/grblas/_ss/vector.py
+++ b/grblas/_ss/vector.py
@@ -96,6 +96,12 @@ class ss:
         return is_iso[0]
 
     @property
+    def iso_value(self):
+        if self.is_iso:
+            return self._parent.reduce(monoid.any).new(name="")
+        raise ValueError("Vector is not iso-valued")
+
+    @property
     def format(self):
         parent = self._parent
         sparsity_ptr = ffi_new("GxB_Option_Field*")

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -137,6 +137,7 @@ def test_from_values_scalar():
     assert C.nvals == 3
     assert C.dtype == dtypes.INT64
     assert C.ss.is_iso
+    assert C.ss.iso_value == 7
     assert C.reduce_scalar(monoid.any).new() == 7
 
     # iso drumps duplicates
@@ -146,9 +147,13 @@ def test_from_values_scalar():
     assert C.nvals == 3
     assert C.dtype == dtypes.INT64
     assert C.ss.is_iso
+    assert C.ss.iso_value == 7
     assert C.reduce_scalar(monoid.any).new() == 7
     with pytest.raises(ValueError, match="dup_op must be None"):
         Matrix.from_values([0, 1, 3, 0], [1, 1, 2, 1], 7, dup_op=binary.plus)
+    C[0, 0] = 0
+    with pytest.raises(ValueError, match="not iso"):
+        C.ss.iso_value
 
 
 def test_clear(A):

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -127,6 +127,7 @@ def test_from_values_scalar():
     assert u.dtype == dtypes.INT64
     if hasattr(u, "ss"):  # pragma: no branch
         assert u.ss.is_iso
+        assert u.ss.iso_value == 7
     assert u.reduce(monoid.any).new() == 7
 
     # ignore duplicate indices; iso trumps duplicates!
@@ -135,9 +136,13 @@ def test_from_values_scalar():
     assert u.nvals == 3
     if hasattr(u, "ss"):  # pragma: no branch
         assert u.ss.is_iso
+        assert u.ss.iso_value == 7
     assert u.reduce(monoid.any).new() == 7
     with pytest.raises(ValueError, match="dup_op must be None"):
         Vector.from_values([0, 1, 1, 3], 7, dup_op=binary.plus)
+    u[0] = 0
+    with pytest.raises(ValueError, match="not iso"):
+        u.ss.iso_value
 
 
 def test_clear(v):


### PR DESCRIPTION
I think it's nice to capture intent here even though this is currently a recipe.  We could make this faster by e.g. using iterators that SuiteSparse:GraphBLAS recently added.

Some possible alternative behaviors of `x.ss.iso_value`:
- If empty, return empty scalar (it currently raises)
- If not iso-valued, return `None` (it currently raises)