### PR TITLE
Broadcast vectors across rows with `plus(A, v)`.

### DIFF
--- a/grblas/_infixmethods.py
+++ b/grblas/_infixmethods.py
@@ -2,6 +2,7 @@ from . import binary, unary
 from .dtypes import BOOL
 from .infix import MatrixInfixExpr, VectorInfixExpr
 from .matrix import Matrix, MatrixExpression, MatrixIndexExpr, TransposedMatrix
+from .operator import _call_op
 from .utils import output_type
 from .vector import Vector, VectorExpression, VectorIndexExpr
 
@@ -17,12 +18,12 @@ def call_op(self, other, method, op, *, outer=False, union=False):
         and type2 is Matrix
     ):
         if outer:
-            return op(self | other, require_monoid=False)
+            return self.ewise_add(other, op, require_monoid=False)
         elif union:
             return self.ewise_union(other, op, False, False)
         else:
-            return op(self & other)
-    return op(self, other)
+            return self.ewise_mul(other, op)
+    return _call_op(op, self, other, broadcast=False)
 
 
 def __divmod__(self, other):

--- a/grblas/_infixmethods.py
+++ b/grblas/_infixmethods.py
@@ -22,7 +22,7 @@ def call_op(self, other, method, op, *, outer=False, union=False):
         elif union:
             return self.ewise_union(other, op, False, False)
         else:
-            return self.ewise_mul(other, op)
+            return self.ewise_mult(other, op)
     return _call_op(op, self, other, broadcast=False)
 
 

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -71,7 +71,7 @@ def _call_op(op, left, right=None, broadcast=True, **kwargs):
     right_type = output_type(right)
     if left_type is Matrix or left_type is TransposedMatrix:
         if right_type is Vector:
-            # Broadcast vector
+            # Broadcast vector rowwise
             if not broadcast:
                 raise TypeError("TODO")
             op, opclass = find_opclass(op)
@@ -81,7 +81,7 @@ def _call_op(op, left, right=None, broadcast=True, **kwargs):
         return left.apply(op, right=right, **kwargs)
     elif left_type is Vector:
         if right_type is Matrix or right_type is TransposedMatrix:
-            # Broadcast vector
+            # Broadcast vector columnwise
             if not broadcast:
                 raise TypeError("TODO")
             op, opclass = find_opclass(op)

--- a/grblas/operator.py
+++ b/grblas/operator.py
@@ -74,9 +74,7 @@ def _call_op(op, left, right=None, broadcast=True, **kwargs):
             # Broadcast vector rowwise
             if not broadcast:
                 raise TypeError("TODO")
-            op, opclass = find_opclass(op)
-            if opclass != "Semiring":
-                op = get_semiring(monoid.any, op)
+            op = get_semiring(monoid.any, op)
             return left.mxm(right.diag(), op, **kwargs)
         return left.apply(op, right=right, **kwargs)
     elif left_type is Vector:
@@ -84,9 +82,7 @@ def _call_op(op, left, right=None, broadcast=True, **kwargs):
             # Broadcast vector columnwise
             if not broadcast:
                 raise TypeError("TODO")
-            op, opclass = find_opclass(op)
-            if opclass != "Semiring":
-                op = get_semiring(monoid.any, op)
+            op = get_semiring(monoid.any, op)
             return left.diag().mxm(right, op, **kwargs)
         return left.apply(op, right=right, **kwargs)
     elif right_type in {Vector, Matrix, TransposedMatrix}:

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -3150,3 +3150,5 @@ def test_broadcast_vector(A, v):
         binary.plus(A, A)
     with pytest.raises(TypeError):
         binary.plus(v, v)
+    with pytest.raises(TypeError):
+        A += v

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -3121,3 +3121,32 @@ def test_delete_via_scalar(A):
     assert A[:, 0].new().nvals == 0
     del A[:, :]
     assert A.nvals == 0
+
+
+def test_broadcast_vector(A, v):
+    result = binary.plus(A, v).new()
+    expected = semiring.any_plus(A @ v.diag()).new()
+    assert result.isequal(expected)
+
+    result = binary.plus(v, A).new()
+    expected = semiring.any_plus(v.diag() @ A).new()
+    assert result.isequal(expected)
+
+    with pytest.raises(TypeError):
+        result = semiring.max_plus(A, v).new()
+    # expected = semiring.max_plus(A @ v.diag()).new()
+    # assert result.isequal(expected)
+
+    with pytest.raises(TypeError):
+        result = semiring.max_plus(v, A).new()
+    # expected = semiring.max_plus(v.diag() @ A).new()
+    # assert result.isequal(expected)
+
+    with pytest.raises(TypeError):
+        (A + v).new()
+    with pytest.raises(TypeError):
+        (v + A).new()
+    with pytest.raises(TypeError):
+        binary.plus(A, A)
+    with pytest.raises(TypeError):
+        binary.plus(v, v)

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -3133,15 +3133,9 @@ def test_broadcast_vector(A, v):
     assert result.isequal(expected)
 
     with pytest.raises(TypeError):
-        result = semiring.max_plus(A, v).new()
-    # expected = semiring.max_plus(A @ v.diag()).new()
-    # assert result.isequal(expected)
-
+        semiring.max_plus(A, v).new()
     with pytest.raises(TypeError):
-        result = semiring.max_plus(v, A).new()
-    # expected = semiring.max_plus(v.diag() @ A).new()
-    # assert result.isequal(expected)
-
+        semiring.max_plus(v, A).new()
     with pytest.raises(TypeError):
         (A + v).new()
     with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #197.  This is the most narrow implementation as described in #197.

Allowed:
- `plus(A, v)` -> `any_plus(A @ v.diag())`
- `plus(v, A)` -> `any_plus(v.diag() @ A)`

Not allowed:
- `min_plus(A, v)`
- `A + v`
- `v + A`
- `A += v`

Need to update error messages before merging (pending approval).