### PR TITLE
Broadcasting! `plus(A & v)` -> `any_plus(A @ v.diag())`

### DIFF
--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -470,7 +470,7 @@ class Matrix(BaseType):
                     f"to rows of Matrix in {method_name}.  Matrix.ncols (={self._ncols}) "
                     f"must equal Vector.size (={other._size})."
                 )
-            full = Vector.new(other.dtype, self._nrows)
+            full = Vector.new(other.dtype, self._nrows, name="v_full")
             full[:] = 0
             other = full.outer(other, binary.second).new(name="M_temp")
         expr = MatrixExpression(
@@ -578,7 +578,7 @@ class Matrix(BaseType):
                     f"to rows of Matrix in {method_name}.  Matrix.ncols (={self._ncols}) "
                     f"must equal Vector.size (={other._size})."
                 )
-            full = Vector.new(other.dtype, self._nrows)
+            full = Vector.new(other.dtype, self._nrows, name="v_full")
             full[:] = 0
             other = full.outer(other, binary.second).new(name="M_temp")
         expr = MatrixExpression(

--- a/grblas/matrix.py
+++ b/grblas/matrix.py
@@ -6,10 +6,10 @@ from . import _automethods, backend, binary, ffi, lib, monoid, semiring, utils
 from ._ss.matrix import ss
 from .base import BaseExpression, BaseType, call
 from .dtypes import _INDEX, lookup_dtype, unify
-from .exceptions import NoValue, check_status
+from .exceptions import DimensionMismatch, NoValue, check_status
 from .expr import AmbiguousAssignOrExtract, IndexerResolver, Updater
 from .mask import StructuralMask, ValueMask
-from .operator import get_typed_op
+from .operator import get_semiring, get_typed_op
 from .scalar import _MATERIALIZE, Scalar, ScalarExpression, _as_scalar
 from .utils import (
     _CArray,
@@ -442,7 +442,7 @@ class Matrix(BaseType):
         method_name = "ewise_add"
         other = self._expect_type(
             other,
-            (Matrix, TransposedMatrix),
+            (Matrix, TransposedMatrix, Vector),
             within=method_name,
             argname="other",
             op=op,
@@ -460,6 +460,19 @@ class Matrix(BaseType):
                 )
         else:
             self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
+        if other.ndim == 1:
+            # Broadcast rowwise from the right
+            # Can we do `C(M.S) << plus(A | v)` -> `C(M.S) << plus(any_second(M @ v.diag()) | A)`?
+            if self._ncols != other._size:
+                # Check this before we compute a possibly large matrix below
+                raise DimensionMismatch(
+                    "Dimensions not compatible for broadcasting Vector from the right "
+                    f"to rows of Matrix in {method_name}.  Matrix.ncols (={self._ncols}) "
+                    f"must equal Vector.size (={other._size})."
+                )
+            full = Vector.new(other.dtype, self._nrows)
+            full[:] = 0
+            other = full.outer(other, binary.second).new(name="M_temp")
         expr = MatrixExpression(
             method_name,
             f"GrB_Matrix_eWiseAdd_{op.opclass}",
@@ -481,11 +494,13 @@ class Matrix(BaseType):
         """
         method_name = "ewise_mult"
         other = self._expect_type(
-            other, (Matrix, TransposedMatrix), within=method_name, argname="other", op=op
+            other, (Matrix, TransposedMatrix, Vector), within=method_name, argname="other", op=op
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
+        if other.ndim == 1:
+            return self.mxm(other.diag(name="M_temp"), get_semiring(monoid.any, op))
         expr = MatrixExpression(
             method_name,
             f"GrB_Matrix_eWiseMult_{op.opclass}",
@@ -512,7 +527,9 @@ class Matrix(BaseType):
         """
         # SS, SuiteSparse-specific: eWiseUnion
         method_name = "ewise_union"
-        other = self._expect_type(other, Matrix, within=method_name, argname="other", op=op)
+        other = self._expect_type(
+            other, (Matrix, TransposedMatrix, Vector), within=method_name, argname="other", op=op
+        )
         if type(left_default) is not Scalar:
             try:
                 left = Scalar.from_value(
@@ -551,11 +568,26 @@ class Matrix(BaseType):
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
         if op.opclass == "Monoid":
             op = op.binaryop
+        if other.ndim == 1:
+            # Broadcast rowwise from the right
+            # Can we do `C(M.S) << plus(A | v)` -> `C(M.S) << plus(any_second(M @ v.diag()) | A)`?
+            if self._ncols != other._size:
+                # Check this before we compute a possibly large matrix below
+                raise DimensionMismatch(
+                    "Dimensions not compatible for broadcasting Vector from the right "
+                    f"to rows of Matrix in {method_name}.  Matrix.ncols (={self._ncols}) "
+                    f"must equal Vector.size (={other._size})."
+                )
+            full = Vector.new(other.dtype, self._nrows)
+            full[:] = 0
+            other = full.outer(other, binary.second).new(name="M_temp")
         expr = MatrixExpression(
             method_name,
             "GxB_Matrix_eWiseUnion",
             [self, left, other, right],
             op=op,
+            at=self._is_transposed,
+            bt=other._is_transposed,
             expr_repr="{0.name}.{method_name}({2.name}, {op}, {1._expr_name}, {3._expr_name})",
         )
         if self.shape != other.shape:

--- a/grblas/tests/test_infix.py
+++ b/grblas/tests/test_infix.py
@@ -113,10 +113,6 @@ def test_bad_ewise(s1, v1, A1, A2):
         (s1, v1),
         (v1, 1),
         (1, v1),
-        (v1, A1),
-        (A1, v1),
-        (v1, A1.T),
-        (A1.T, v1),
         (A1, s1),
         (s1, A1),
         (A1.T, s1),
@@ -128,6 +124,31 @@ def test_bad_ewise(s1, v1, A1, A2):
             left | right
         with raises(TypeError, match="Bad type for argument"):
             left & right
+    # These are okay now
+    for left, right in [
+        (A1, v1),
+        (v1, A1.T),
+    ]:
+        left.ewise_add(right)
+        left | right
+        left.ewise_mult(right)
+        left & right
+        left.ewise_union(right, op.plus, 0, 0)
+    # Wrong dimension; can't broadcast
+    for left, right in [
+        (v1, A1),
+        (A1.T, v1),
+    ]:
+        with raises(DimensionMismatch):
+            left | right
+        with raises(DimensionMismatch):
+            left & right
+        with raises(DimensionMismatch):
+            left.ewise_add(right)
+        with raises(DimensionMismatch):
+            left.ewise_mult(right)
+        with raises(DimensionMismatch):
+            left.ewise_union(right, op.plus, 0, 0)
 
     w = v1[: v1.size - 1].new()
     with raises(DimensionMismatch):

--- a/grblas/tests/test_matrix.py
+++ b/grblas/tests/test_matrix.py
@@ -3088,6 +3088,14 @@ def test_ewise_union():
     result = A1.ewise_union(A2, binary.plus, 10, 20).new()
     expected = Matrix.from_values([0, 0], [0, 1], [21, 12], nrows=1, ncols=3)
     assert result.isequal(expected)
+
+    # Test transposed
+    A2transposed = A2.T.new()
+    result = A1.ewise_union(A2transposed.T, binary.plus, 10, 20).new()
+    assert result.isequal(expected)
+    result = A1.T.ewise_union(A2transposed, binary.plus, 10, 20).new()
+    assert result.isequal(expected.T.new())
+
     # Handle Scalars
     result = A1.ewise_union(A2, binary.plus, Scalar.from_value(10), Scalar.from_value(20)).new()
     assert result.isequal(expected)

--- a/grblas/tests/test_operator_types.py
+++ b/grblas/tests/test_operator_types.py
@@ -158,6 +158,7 @@ IGNORE = {
     "myplus",
     "plus_myplus",
     "plus_numpy_copysign",
+    "any_any",
     # numpy-graphblas commutation (can we clean this up?)
     "band_land",
     "band_lor",

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1763,3 +1763,34 @@ def test_broadcasting(A, v):
     (A.dup(bool) & v.dup(bool)).new()  # okay
     with pytest.raises(TypeError):
         v += A
+
+
+def test_ewise_union_infix():
+    v = Vector.new(int, 3)
+    w = Vector.new(int, 3)
+    v[0] = 1
+    w[1] = 2
+    result = binary.plus(v | w, left_default=10, right_default=20).new()
+    expected = Vector.from_values([0, 1], [21, 12], size=3)
+    assert expected.isequal(result)
+    result = monoid.plus(v | w, left_default=10, right_default=20).new()
+    assert expected.isequal(result)
+    for op in [binary.plus, monoid.plus]:
+        with pytest.raises(TypeError):
+            op(v & w, left_default=10, right_default=20)
+        with pytest.raises(TypeError):
+            op(v @ w, left_default=10, right_default=20)
+        with pytest.raises(TypeError):
+            op(v | w, right_default=20)
+        with pytest.raises(TypeError):
+            op(v | w, left_default=20)
+        with pytest.raises(TypeError):
+            op(v | w, left_default=10, right_default=20, require_monoid=True)
+        with pytest.raises(TypeError):
+            op(v | w, left_default=10, right_default=20, require_monoid=False)
+        with pytest.raises(TypeError):
+            op(v | w, right_default=20, require_monoid=True)
+        with pytest.raises(TypeError):
+            op(v & w, 5, left_default=10, right_default=20)
+        with pytest.raises(TypeError):
+            op(v, w, left_default=10, right_default=20)

--- a/grblas/tests/test_vector.py
+++ b/grblas/tests/test_vector.py
@@ -1763,6 +1763,9 @@ def test_broadcasting(A, v):
     (A.dup(bool) & v.dup(bool)).new()  # okay
     with pytest.raises(TypeError):
         v += A
+    with pytest.raises(TypeError):
+        binary.minus(v | A)
+    binary.minus(v | A, require_monoid=False)
 
 
 def test_ewise_union_infix():

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -437,7 +437,7 @@ class Vector(BaseType):
             full = Vector.new(self.dtype, other._ncols)
             full[:] = 0
             temp = self.outer(full, binary.first).new(name="M_temp")
-            return temp.ewise_add(other, op)
+            return temp.ewise_add(other, op, require_monoid=False)
         expr = VectorExpression(
             method_name,
             f"GrB_Vector_eWiseAdd_{op.opclass}",

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -434,7 +434,7 @@ class Vector(BaseType):
                     f"to columns of Matrix in {method_name}.  Matrix.nrows (={other._nrows}) "
                     f"must equal Vector.size (={self._size})."
                 )
-            full = Vector.new(self.dtype, other._ncols)
+            full = Vector.new(self.dtype, other._ncols, name="v_full")
             full[:] = 0
             temp = self.outer(full, binary.first).new(name="M_temp")
             return temp.ewise_add(other, op, require_monoid=False)
@@ -543,7 +543,7 @@ class Vector(BaseType):
                     f"to columns of Matrix in {method_name}.  Matrix.nrows (={other._nrows}) "
                     f"must equal Vector.size (={self._size})."
                 )
-            full = Vector.new(self.dtype, other._ncols)
+            full = Vector.new(self.dtype, other._ncols, name="v_full")
             full[:] = 0
             temp = self.outer(full, binary.first).new(name="M_temp")
             return temp.ewise_union(other, op, left_default, right_default)

--- a/grblas/vector.py
+++ b/grblas/vector.py
@@ -6,7 +6,7 @@ from . import _automethods, backend, binary, ffi, lib, monoid, semiring, utils
 from ._ss.vector import ss
 from .base import BaseExpression, BaseType, call
 from .dtypes import _INDEX, lookup_dtype, unify
-from .exceptions import NoValue, check_status
+from .exceptions import DimensionMismatch, NoValue, check_status
 from .expr import AmbiguousAssignOrExtract, IndexerResolver, Updater
 from .mask import StructuralMask, ValueMask
 from .operator import get_semiring, get_typed_op
@@ -405,8 +405,12 @@ class Vector(BaseType):
         performing any operation. In the case of `gt`, the non-empty value is cast to a boolean.
         For these reasons, users are required to be explicit when choosing this surprising behavior.
         """
+        from .matrix import Matrix, TransposedMatrix
+
         method_name = "ewise_add"
-        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
+        other = self._expect_type(
+            other, (Vector, Matrix, TransposedMatrix), within=method_name, argname="other", op=op
+        )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         if require_monoid:
@@ -420,6 +424,20 @@ class Vector(BaseType):
                 )
         else:
             self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
+        if other.ndim == 2:
+            # Broadcast columnwise from the left
+            # Can we do `C(M.S) << plus(v | A)` -> `C(M.S) << plus(any_first(v.diag() @ M) | A)`?
+            if other._nrows != self._size:
+                # Check this before we compute a possibly large matrix below
+                raise DimensionMismatch(
+                    "Dimensions not compatible for broadcasting Vector from the left "
+                    f"to columns of Matrix in {method_name}.  Matrix.nrows (={other._nrows}) "
+                    f"must equal Vector.size (={self._size})."
+                )
+            full = Vector.new(self.dtype, other._ncols)
+            full[:] = 0
+            temp = self.outer(full, binary.first).new(name="M_temp")
+            return temp.ewise_add(other, op)
         expr = VectorExpression(
             method_name,
             f"GrB_Vector_eWiseAdd_{op.opclass}",
@@ -437,11 +455,17 @@ class Vector(BaseType):
         Result will contain the intersection of indices from both Vectors
         Default op is binary.times
         """
+        from .matrix import Matrix, TransposedMatrix
+
         method_name = "ewise_mult"
-        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
+        other = self._expect_type(
+            other, (Vector, Matrix, TransposedMatrix), within=method_name, argname="other", op=op
+        )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
+        if other.ndim == 2:
+            return self.diag(name="M_temp").mxm(other, get_semiring(monoid.any, op))
         expr = VectorExpression(
             method_name,
             f"GrB_Vector_eWiseMult_{op.opclass}",
@@ -465,8 +489,12 @@ class Vector(BaseType):
         ``op`` should be a BinaryOp or Monoid.
         """
         # SS, SuiteSparse-specific: eWiseUnion
+        from .matrix import Matrix, TransposedMatrix
+
         method_name = "ewise_union"
-        other = self._expect_type(other, Vector, within=method_name, argname="other", op=op)
+        other = self._expect_type(
+            other, (Vector, Matrix, TransposedMatrix), within=method_name, argname="other", op=op
+        )
         if type(left_default) is not Scalar:
             try:
                 left = Scalar.from_value(
@@ -505,6 +533,20 @@ class Vector(BaseType):
         self._expect_op(op, ("BinaryOp", "Monoid"), within=method_name, argname="op")
         if op.opclass == "Monoid":
             op = op.binaryop
+        if other.ndim == 2:
+            # Broadcast columnwise from the left
+            # Can we do `C(M.S) << plus(v | A)` -> `C(M.S) << plus(any_first(v.diag() @ M) | A)`?
+            if other._nrows != self._size:
+                # Check this before we compute a possibly large matrix below
+                raise DimensionMismatch(
+                    "Dimensions not compatible for broadcasting Vector from the left "
+                    f"to columns of Matrix in {method_name}.  Matrix.nrows (={other._nrows}) "
+                    f"must equal Vector.size (={self._size})."
+                )
+            full = Vector.new(self.dtype, other._ncols)
+            full[:] = 0
+            temp = self.outer(full, binary.first).new(name="M_temp")
+            return temp.ewise_union(other, op, left_default, right_default)
         expr = VectorExpression(
             method_name,
             "GxB_Vector_eWiseUnion",


### PR DESCRIPTION
Fixes #197, and implements nearly everything in the alt proposal.

Supersedes https://github.com/metagraph-dev/grblas/pull/202.

This doesn't perform a faster recipe `C(M.S) << plus(A | v)` -> `C(M.S) << plus(A | any_second(M @ v.diag())`.  Although I think this recipe would be a lot faster and more memory efficient, it's also difficult to implement.